### PR TITLE
chore: 더미데이터 삭제

### DIFF
--- a/views/play.ejs
+++ b/views/play.ejs
@@ -90,12 +90,12 @@
     <div id="loadingContainer">
       <div id="albumContainer">
         <div id="albumInfo">
-          <span id="author">Pattern by - <span id="authorNamespace">Author</span></span>
-          <span><span id="albumDifficulty">MID</span>&nbsp;<span id="albumDifficultyNum">5</span></span>
+          <span id="author">Pattern by - <span id="authorNamespace"></span></span>
+          <span><span id="albumDifficulty"></span>&nbsp;<span id="albumDifficultyNum"></span></span>
         </div>
       </div>
-      <span id="title">Title</span>
-      <span id="artist">Various Artists</span>
+      <span id="title"></span>
+      <span id="artist"></span>
       <span id="loadingUrlate">URLATE <span id="loadingLite">LITE</span></span>
       <div id="authorContainer">
         <img src="" id="authorIcon" />

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -91,12 +91,12 @@
     <div id="loadingContainer">
       <div id="albumContainer">
         <div id="albumInfo">
-          <span id="author">Pattern by - <span id="authorNamespace">Author</span></span>
+          <span id="author">Pattern by - <span id="authorNamespace"></span></span>
           <span><span id="albumDifficulty">TEST</span>&nbsp;<span id="albumDifficultyNum">MODE</span></span>
         </div>
       </div>
-      <span id="title">Title</span>
-      <span id="artist">Various Artists</span>
+      <span id="title"></span>
+      <span id="artist"></span>
       <span id="loadingUrlate">URLATE <span id="loadingLite">LITE</span></span>
       <div id="authorContainer">
         <img src="" id="authorIcon" />

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -90,12 +90,12 @@
     <div id="loadingContainer">
       <div id="albumContainer">
         <div id="albumInfo">
-          <span id="author">Pattern by - <span id="authorNamespace">Author</span></span>
-          <span><span id="albumDifficulty">MID</span>&nbsp;<span id="albumDifficultyNum">5</span></span>
+          <span id="author">Pattern by - <span id="authorNamespace"></span></span>
+          <span><span id="albumDifficulty"></span>&nbsp;<span id="albumDifficultyNum"></span></span>
         </div>
       </div>
-      <span id="title">Title</span>
-      <span id="artist">Various Artists</span>
+      <span id="title"></span>
+      <span id="artist"></span>
       <span id="loadingUrlate">URLATE <span id="loadingLite">LITE</span></span>
     </div>
     <div id="floatingResultContainer">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 플레이, 테스트, 튜토리얼 화면에서 로딩 중 표시되는 앨범 정보(제목, 아티스트, 저자, 난이도 등)의 기본 플레이스홀더 텍스트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->