### PR TITLE
fix: no intro 초기화시 특정 조건에서 로딩 순서가 꼬이는 문제

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -377,8 +377,6 @@ document.addEventListener("DOMContentLoaded", () => {
     warningInner.style.borderBottom = "0.1vh solid #555";
   }, 3000);
   if (iniMode != -1) {
-    //no intro
-    loaded++;
     display = 0;
   } else {
     warningContainer.style.display = "flex";
@@ -588,6 +586,13 @@ const tracksUpdate = () => {
                 maxcombo: 0,
               };
             }
+          }
+        }
+        if (i == tracks.length - 1 && iniMode != -1) {
+          loaded++;
+          if (loaded == 4) {
+            loaded = -1;
+            gameLoaded();
           }
         }
       })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 게임 로딩 완료 시점을 트랙의 마지막 기록이 모두 불러와진 후로 조정하여, 초기화 시 로딩 상태가 잘못 표시되는 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->