### PR TITLE
Change-calculate-exp

### DIFF
--- a/public/js/play.js
+++ b/public/js/play.js
@@ -1448,7 +1448,12 @@ const calculateScore = (judge, i, ignoreMs) => {
       maxCombo = combo;
     }
     let basicScore = 100000000 / patternLength;
-    const rateCalc = rate * 0.5 + 0.5;
+    let rateCalc = rate;
+    if (rate >= 1) {
+      rateCalc = rate * 0.5 + 0.5;
+    } else {
+      rateCalc = rate * rate * 1.3 - 0.3;
+    }
     if (judge == "perfect") {
       score += Math.round((basicScore + combo * 5) * rateCalc);
     } else {

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -1373,7 +1373,12 @@ const calculateScore = (judge, i, ignoreMs) => {
     maxCombo = combo;
   }
   let basicScore = 100000000 / patternLength;
-  const rateCalc = rate * 0.5 + 0.5;
+  let rateCalc = rate;
+  if (rate >= 1) {
+    rateCalc = rate * 0.5 + 0.5;
+  } else {
+    rateCalc = rate * rate * 1.3 - 0.3;
+  }
   if (judge == "perfect") {
     score += Math.round((basicScore + combo * 5) * rateCalc);
   } else {

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -1358,7 +1358,12 @@ const calculateScore = (judge, i, ignoreMs) => {
     maxCombo = combo;
   }
   let basicScore = 100000000 / patternLength;
-  const rateCalc = rate * 0.5 + 0.5;
+  let rateCalc = rate;
+  if (rate >= 1) {
+    rateCalc = rate * 0.5 + 0.5;
+  } else {
+    rateCalc = rate * rate * 1.3 - 0.3;
+  }
   if (judge == "perfect") {
     score += Math.round((basicScore + combo * 5) * rateCalc);
   } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 점수 계산 시 rate 값이 1 미만일 때 점수 배율이 비선형적으로 적용되도록 개선되었습니다. 이제 rate가 1 이상이면 기존과 동일하게 계산되며, 1 미만일 경우 새로운 방식으로 점수가 산정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->