### PR TITLE
fix: 일부 환경에서 montserrat 폰트의 line-height가 지나치게 크게 나타나던 문제

### DIFF
--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -3,6 +3,7 @@
 @import url("metropolis.css");
 
 body {
+  line-height: 1.2;
   background: #eee url("/images/backgrounds/editor.webp");
   background-size: 130vw;
   background-repeat: repeat;

--- a/public/css/error.css
+++ b/public/css/error.css
@@ -1,6 +1,7 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-jp.css");
 
 body {
+  line-height: 1.2;
   width: 100vw;
   height: 100vh;
   margin: 0;

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -10,6 +10,7 @@
 }
 
 body {
+  line-height: 1.2;
   background-size: cover;
   background-position: center;
   background-image: url("/images/backgrounds/main.webp");

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -2,6 +2,7 @@
 @import url("https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap");
 
 body {
+  line-height: 1.2;
   margin: 0;
   padding: 0;
   text-align: center;

--- a/public/css/info.css
+++ b/public/css/info.css
@@ -2,6 +2,7 @@
 @import url("https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap");
 
 body {
+  line-height: 1.2;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/public/css/join.css
+++ b/public/css/join.css
@@ -2,6 +2,7 @@
 @import url("https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap");
 
 body {
+  line-height: 1.2;
   width: 100vw;
   height: 100vh;
   margin: 0;

--- a/public/css/play.css
+++ b/public/css/play.css
@@ -2,6 +2,7 @@
 @import url("https://fonts.googleapis.com/css?family=Montserrat:400,500,600,800&display=swap");
 
 body {
+  line-height: 1.2;
   background: black;
   background-repeat: repeat;
   width: 100vw;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 전체 페이지(에디터, 오류, 게임, 메인, 정보, 참여, 플레이)의 기본 본문 줄간격을 1.2로 통일해 가독성을 개선했습니다.
  - 텍스트 사이 여백이 균형 있게 조정되어 긴 문단과 다양한 화면 크기에서 읽기 편의성이 향상됩니다.
  - 시각적 일관성을 높여 페이지 전반의 레이아웃 안정감을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->