### PR TITLE
Potential fix for code scanning alert no. 15: Prototype-polluting function

### DIFF
--- a/public/js/pace.js
+++ b/public/js/pace.js
@@ -136,8 +136,8 @@
       d = function () {
         for (var t, e, n, r = arguments[0], s = 2 <= arguments.length ? J.call(arguments, 1) : [], o = 0, i = s.length; o < i; o++)
           if ((e = s[o])) for (t in e) {
-            if (K.call(e, t) && (t === "__proto__" || t === "constructor" || t === "prototype")) continue;
             if (K.call(e, t)) {
+              if (t === "__proto__" || t === "constructor" || t === "prototype") continue;
               n = e[t];
               null != r[t] && "object" == typeof r[t] && null != n && "object" == typeof n ? d(r[t], n) : (r[t] = n);
             }


### PR DESCRIPTION
Potential fix for [https://github.com/HyeokjinKang/URLATE/security/code-scanning/15](https://github.com/HyeokjinKang/URLATE/security/code-scanning/15)

To fix this vulnerability, the key property names responsible for prototype pollution must be blocked during assignment inside the merge function. The best practice is to skip keys named `__proto__`, `constructor`, or `prototype` before assigning or recursively merging them. Using a simple key check immediately before either recursive call or assignment achieves this. 

Specifically, in the code region at line 138 inside the `d` function definition, add a conditional to skip the iteration for unsafe keys. The fix should check if `t` equals `"__proto__"`, `"constructor"`, or `"prototype"`, and use `continue` to skip such assignments. No additional libraries are required for this fix.

Only the shown `public/js/pace.js` file needs to be changed, in the region of the `d` function definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
