### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Build
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/HyeokjinKang/URLATE/security/code-scanning/21](https://github.com/HyeokjinKang/URLATE/security/code-scanning/21)

To fix the issue, add an explicit `permissions:` block to the workflow specifying only the minimum required privileges. Since the job only checks out code and installs/builds dependencies, `contents: read` is the minimal necessary permission. The best place to add this is near the top of the workflow, after the `name:` field and before the `on:` block, so the restriction applies to all jobs in the workflow by default. No further changes are needed unless specific jobs require additional permissions.

**Edit required:**  
- File: `.github/workflows/build.yml`
- Region: After line 3 (`name: Build`), insert a `permissions:` block with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
