### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Build and Deploy
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/HyeokjinKang/URLATE/security/code-scanning/20](https://github.com/HyeokjinKang/URLATE/security/code-scanning/20)

The fix is to add a `permissions:` block with the appropriate minimal permissions to the workflow. Since reviewing the workflow reveals that none of the steps require special GitHub write permissions (they just check out code, build, and copy files to a remote host), it is safe—and best practice—to set the global `permissions:` to `contents: read` at the workflow level (right after the `name:` line, and before `jobs:`). This ensures jobs and steps do not have unnecessary permissions, reducing potential attack surface.

Only one file, `.github/workflows/deploy.yml`, needs to be changed.  
No imports, method definitions, or new packages are required, as this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
