### PR TITLE
성능·보안 개선: 폰트 로딩 최적화, XSS 방어, 보안 헤더, 인트로 게이트 리팩터

### DIFF
--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -1,7 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900");
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css");
-@import url("metropolis.css");
-
 :root {
   --font-stack-base:
     "Pretendard JP Variable", "Pretendard JP", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Hiragino Sans", "Apple SD Gothic Neo", Meiryo,

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -1,7 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900");
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css");
-@import url("metropolis.css");
-
 @-moz-document url-prefix() {
   #selectRankInnerContainer {
     background-color: #222 !important;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1,6 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900");
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css");
-
 body {
   line-height: 1.2;
   margin: 0;

--- a/public/css/info.css
+++ b/public/css/info.css
@@ -1,6 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900");
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css");
-
 body {
   line-height: 1.2;
   display: flex;

--- a/public/css/join.css
+++ b/public/css/join.css
@@ -1,6 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900");
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css");
-
 body {
   line-height: 1.2;
   width: 100vw;

--- a/public/css/metropolis.css
+++ b/public/css/metropolis.css
@@ -1,53 +1,62 @@
 @font-face {
   font-family: "Metropolis";
   font-weight: 400;
+  font-display: swap;
   src: local("Metropolis Regular"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-Regular.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 200;
+  font-display: swap;
   src: local("Metropolis Extra Light"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-ExtraLight.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 300;
+  font-display: swap;
   src: local("Metropolis Light"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-Light.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 100;
+  font-display: swap;
   src: local("Metropolis Thin"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-Thin.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 500;
+  font-display: swap;
   src: local("Metropolis Medium"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-Medium.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 600;
+  font-display: swap;
   src: local("Metropolis Semi Bold"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-SemiBold.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 700;
+  font-display: swap;
   src: local("Metropolis Bold"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-Bold.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 800;
+  font-display: swap;
   src: local("Metropolis Extra Bold"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-ExtraBold.woff") format("woff");
 }
 
 @font-face {
   font-family: "Metropolis";
   font-weight: 900;
+  font-display: swap;
   src: local("Metropolis Black"), url("https://cdn.urlate.coupy.dev/fonts/Metropolis-Black.woff") format("woff");
 }

--- a/public/css/play.css
+++ b/public/css/play.css
@@ -1,6 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900");
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css");
-
 :root {
   --font-stack-base:
     "Pretendard JP Variable", "Pretendard JP", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Hiragino Sans", "Apple SD Gothic Neo", Meiryo,

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -221,7 +221,7 @@ document.addEventListener("DOMContentLoaded", () => {
         tracks = data.tracks;
         for (let i = 0; tracks.length > i; i++) {
           let option = document.createElement("option");
-          option.innerHTML = tracks[i].name;
+          option.textContent = tracks[i].name;
           if (tracks[i].type == 3) option.disabled = true;
           songSelectBox.options.add(option);
         }

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1077,15 +1077,9 @@ const menuSelected = (n) => {
     //play
     display = 1;
     if (songSelection == -1) {
-      // eslint-disable-next-line no-constant-condition
-      while (1) {
-        let min = Math.ceil(0);
-        let max = Math.floor(tracks.length);
-        let result = Math.floor(Math.random() * (max - min)) + min;
-        if (tracks[result].type != 3) {
-          songSelected(result);
-          break;
-        }
+      const playable = tracks.map((t, i) => (t.type != 3 ? i : -1)).filter((i) => i != -1);
+      if (playable.length > 0) {
+        songSelected(playable[Math.floor(Math.random() * playable.length)]);
       }
     }
     document.getElementById("selectContainer").style.display = "flex";

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -804,10 +804,15 @@ const gameLoaded = () => {
   Howler.masterGain.connect(analyser);
   dataArray = new Uint8Array(analyser.frequencyBinCount);
   animationLooper();
-  tracks.forEach((e) => {
-    const img = new Image();
-    img.src = `${cdn}/albums/${settings.display.albumRes}/${e.fileName}.webp`;
-  });
+  // Warm the album-art cache during idle time so it doesn't block initial render.
+  const preloadAlbums = () => {
+    tracks.forEach((e) => {
+      const img = new Image();
+      img.src = `${cdn}/albums/${settings.display.albumRes}/${e.fileName}.webp`;
+    });
+  };
+  if (window.requestIdleCallback) requestIdleCallback(preloadAlbums);
+  else setTimeout(preloadAlbums, 1000);
 };
 
 Pace.on("done", () => {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -47,6 +47,12 @@ const profileNameContainer = document.getElementById("profileNameContainer");
 const slowRate = 110 / 174;
 const fastRate = 174 / 110;
 
+// escapeHtml/safeUrl are shared from modules/utils.js (game.js is a classic script, so import dynamically).
+let escapeHtml, safeUrl;
+(async () => {
+  ({ escapeHtml, safeUrl } = await import("../modules/utils.js"));
+})();
+
 let settings = [];
 let profileSong;
 let display = -1;
@@ -742,7 +748,7 @@ const updateRanks = () => {
         innerContent += `<br>
                         <div class="selectRank">
                           <div class="selectRankNumber">${i + 1 - rankMinus}</div>
-                          <div class="selectRankName">${data[i].nickname}</div>
+                          <div class="selectRankName">${escapeHtml(data[i].nickname)}</div>
                           <div class="selectRankScore">${numberWithCommas(Number(data[i].record))}</div>
                       </div>`;
         prevScore = data[i].record;
@@ -1115,9 +1121,9 @@ const rankUpdate = async () => {
         (e, i) => `<tr>
       <td>${i + 1}</td>
       <td>
-        <div class="rankProfileContainer" onclick="profileScreen('${e.userid}')">
-          <img src="${e.picture}" class="rankProfile ${e.explicit % 2 == 1 ? "blur" : ""}" />
-          ${e.nickname}
+        <div class="rankProfileContainer" onclick="profileScreen('${encodeURIComponent(e.userid)}')">
+          <img src="${escapeHtml(safeUrl(e.picture))}" class="rankProfile ${e.explicit % 2 == 1 ? "blur" : ""}" />
+          ${escapeHtml(e.nickname)}
         </div>
       </td>
       <td>${Number(e.accuracy).toFixed(2)}%</td>
@@ -1159,8 +1165,8 @@ const profileUpdate = async (uid, isMe) => {
     if (profile.explicit % 2 == 1) {
       document.getElementById("profileImage").classList.add("blur");
     }
-    document.getElementById("profileImageContainer").style.backgroundImage = `url("${profile.background}")`;
-    document.getElementById("profileImage").src = profile.picture;
+    document.getElementById("profileImageContainer").style.backgroundImage = `url("${safeUrl(profile.background)}")`;
+    document.getElementById("profileImage").src = safeUrl(profile.picture);
     document.getElementById("profileName").textContent = profile.nickname;
     document.getElementById("profileBio").textContent = `| ${alias[profile.alias]}`;
     document.getElementById("profileRank").textContent = `#${numberWithCommas(rank)}`;
@@ -1177,7 +1183,7 @@ const profileUpdate = async (uid, isMe) => {
       if (banners[i].indexOf("(-)") != -1 && !isMe) continue;
       count++;
       document.getElementById("profileBannerContainer").innerHTML += `
-        <div class="bannerImage${isMe ? " clickable" : ""}${banners[i].indexOf("(-)") != -1 ? " hidden" : ""}" style="background-image: url('${cdn}/banners/${banners[i].replace("(-)", "")}.webp')" ${
+        <div class="bannerImage${isMe ? " clickable" : ""}${banners[i].indexOf("(-)") != -1 ? " hidden" : ""}" style="background-image: url('${cdn}/banners/${encodeURIComponent(banners[i].replace("(-)", ""))}.webp')" ${
           isMe ? `onclick="bannerToggle(${i})"` : ""
         }>
           <div class="bannerHover">
@@ -1213,7 +1219,7 @@ const profileUpdate = async (uid, isMe) => {
                 </div>
               </div>
               <div class="playContainerRight">
-                <span class="playDetail">${data.judge}</span>
+                <span class="playDetail">${escapeHtml(data.judge)}</span>
                 <span class="playDetail">${numberWithCommas(Number(data.record))}</span>
                 <span class="playDetail">${Number(data.accuracy).toFixed(2)}%</span>
                 <span class="playRate">${rating} +${Number(data.rating / 100).toFixed(2)}</span>
@@ -1246,7 +1252,7 @@ const profileUpdate = async (uid, isMe) => {
           </div>
         </div>
         <div class="playContainerRight">
-          <span class="playDetail">${data.judge}</span>
+          <span class="playDetail">${escapeHtml(data.judge)}</span>
           <span class="playDetail">${numberWithCommas(Number(data.record))}</span>
           <span class="playDetail">${Number(data.accuracy).toFixed(2)}%</span>
           <span class="playRate">${rating} ${data.rating == 0 ? "-" : `+${Number(data.rating / 100).toFixed(2)}`}</span>
@@ -1490,7 +1496,7 @@ const showProfile = (name) => {
         innerHTML += `
                     <div class="infoProfilePart">
                         <img src="/icons/${info[i].icon}.svg" class="infoIcon">
-                        ${link == "" ? `<span>` : `<a class="blackLink" href="${link}" target="_blank">`}${info[i].content}${link == "" ? `</span>` : `</a>`}
+                        ${link == "" ? `<span>` : `<a class="blackLink" href="${link}" target="_blank" rel="noopener noreferrer">`}${info[i].content}${link == "" ? `</span>` : `</a>`}
                     </div>`;
       }
       document.getElementById("infoProfileBottom").innerHTML = innerHTML;

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1,4 +1,4 @@
-/* global Howler, Howl, Pace, Chart, iziToast, url, cdn, api, lang, confirmExit, pressAnywhere, introload, notAvailable1, notAvailable2, medalDesc, alias, nothingHere, rating, couponApplySuccess, couponInvalid1, couponInvalid2, couponUsed, inputEmpty, aliasSelect, pictureMessage, imageError */
+/* global Howler, Howl, Pace, Chart, iziToast, url, cdn, api, lang, confirmExit, pressAnywhere, notAvailable1, notAvailable2, medalDesc, alias, nothingHere, rating, couponApplySuccess, couponInvalid1, couponInvalid2, couponUsed, inputEmpty, aliasSelect, pictureMessage, imageError */
 const langDetailSelector = document.getElementById("langDetailSelector");
 const canvasResSelector = document.getElementById("canvasResSelector");
 const albumResSelector = document.getElementById("albumResSelector");
@@ -327,6 +327,37 @@ const warningSkip = () => {
   }
 };
 
+// Intro gate: enable "press anywhere" once both intro videos are loaded
+// and the warning screen has been shown for at least 3 seconds.
+const introReady = { video1: false, video2: false, minDelay: false, done: false };
+
+const checkIntroReady = () => {
+  if (introReady.done || !(introReady.video1 && introReady.video2 && introReady.minDelay)) return;
+  introReady.done = true;
+  document.getElementById("pressAnywhere").textContent = pressAnywhere;
+  warningContainer.onclick = warningSkip;
+};
+
+const watchIntroVideo = (video, key) => {
+  // readyState >= HAVE_CURRENT_DATA means loadeddata already fired before this script ran.
+  if (video.readyState >= 2) {
+    introReady[key] = true;
+    checkIntroReady();
+  } else {
+    video.addEventListener(
+      "loadeddata",
+      () => {
+        introReady[key] = true;
+        checkIntroReady();
+      },
+      { once: true },
+    );
+  }
+};
+
+watchIntroVideo(intro1video, "video1");
+watchIntroVideo(intro2video, "video2");
+
 const intro1skip = () => {
   intro1video.pause();
   if (!intro1skipped) {
@@ -373,12 +404,8 @@ document.addEventListener("DOMContentLoaded", () => {
     warningInner.style.opacity = "1";
   }, 1000);
   setTimeout(() => {
-    if (introload == 2) {
-      document.getElementById("pressAnywhere").textContent = pressAnywhere;
-      document.getElementById("warningContainer").onclick = warningSkip;
-    }
-    // eslint-disable-next-line no-global-assign
-    introload++;
+    introReady.minDelay = true;
+    checkIntroReady();
     document.getElementById("pressAnywhere").style.opacity = "1";
     warningInner.style.borderBottom = "0.1vh solid #555";
   }, 3000);

--- a/public/modules/utils.js
+++ b/public/modules/utils.js
@@ -1,3 +1,13 @@
+// Escape user-controlled strings before inserting into innerHTML (XSS prevention).
+export const escapeHtml = (value) =>
+  String(value ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]);
+
+// Only allow http(s) or root-relative URLs; block javascript:/data: schemes in src/background contexts.
+export const safeUrl = (value) => {
+  const str = String(value ?? "").trim();
+  return /^https?:\/\//i.test(str) || str.startsWith("/") ? str : "";
+};
+
 export const numberWithCommas = (n) => {
   let str = (~~n).toString();
   let head = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,17 @@ app.locals.pretty = true;
 app.set("view engine", "ejs");
 app.set("views", __dirname + "/../views");
 app.use(cookieParser());
-app.use(express.static(__dirname + "/../public"));
+
+// Baseline security headers (CSP omitted: inline event handlers require a larger refactor).
+app.use((req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "SAMEORIGIN");
+  res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+  next();
+});
+
+// Static assets are cache-busted via ?v=<ver>, so a long max-age is safe.
+app.use(express.static(__dirname + "/../public", { maxAge: "7d" }));
 app.use(i18n);
 
 app.get("/", (req, res) => {

--- a/views/editor.ejs
+++ b/views/editor.ejs
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Editor</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.urlate.coupy.dev" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
+    <link rel="stylesheet" href="/css/metropolis.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/iziToast.min.css" />
     <link rel="stylesheet" href="/css/globalSocket.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/editor.css?v=<%= ver %>" />

--- a/views/editor.ejs
+++ b/views/editor.ejs
@@ -492,7 +492,7 @@
       const moveToAlert = "<%= __('moveToAlert') %>";
       const timeAlert = "<%= __('timeAlert') %>";
       const copiedText = "<%= __('copied') %>";
-      const syncAlert = "<%- __('syncAlert') %>";
+      const syncAlert = "<%= __('syncAlert') %>";
       const rangeCopyAlert = "<%= __('rangeCopyAlert') %>";
       const cdn = "<%= cdn %>";
       const url = "<%= url %>";

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <title>URLATE Client</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.urlate.coupy.dev" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
+    <link rel="stylesheet" href="/css/metropolis.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/iziToast.min.css" />
     <link rel="stylesheet" href="/css/globalSocket.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/game.css?v=<%= ver %>" />

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -15,25 +15,6 @@
     <link rel="stylesheet" href="/css/game.css?v=<%= ver %>" />
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <script data-pace-options='{ "eventLag": false }' src="/js/pace.js"></script>
-    <script>
-      let introload = 0;
-
-      const intro1loaded = () => {
-        if (introload == 2) {
-          document.getElementById("pressAnywhere").textContent = pressAnywhere;
-          document.getElementById("warningContainer").onclick = warningSkip;
-        }
-        introload++;
-      };
-
-      const intro2loaded = () => {
-        if (introload == 2) {
-          document.getElementById("pressAnywhere").textContent = pressAnywhere;
-          document.getElementById("warningContainer").onclick = warningSkip;
-        }
-        introload++;
-      };
-    </script>
   </head>
   <body oncontextmenu="return false;" ondragstart="return false;" onselect="return false;">
     <div id="footer">
@@ -61,13 +42,13 @@
       <span id="pressAnywhere"><%= __('loading') %></span>
     </div>
     <div id="intro1container" class="introContainer" onclick="intro1skip()">
-      <video id="intro1video" onloadeddata="intro1loaded()">
+      <video id="intro1video">
         <source type="video/webm" src="<%= cdn %>/videos/croissant.webm" />
         <source type="video/mp4" src="<%= cdn %>/videos/croissant.mp4" />
       </video>
     </div>
     <div id="intro2container" class="introContainer" onclick="intro2skip()">
-      <video id="intro2video" onloadeddata="intro2loaded()">
+      <video id="intro2video">
         <source type="video/webm" src="<%= cdn %>/videos/coupyworks.webm" />
         <source type="video/mp4" src="<%= cdn %>/videos/coupyworks.mp4" />
       </video>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,6 +10,11 @@
     <meta property="og:image" content="/images/mainImage.png" />
     <meta name="naver-site-verification" content="7ae378668c928c7b17400b60b364b844a751c1f1" />
     <link rel="shortcut icon" href="/images/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
     <link rel="stylesheet" href="/css/index.css?v=<%= ver %>" />
     <title>URLATE</title>
   </head>

--- a/views/info.ejs
+++ b/views/info.ejs
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
     <link rel="stylesheet" href="/css/info.css" />
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <title>URLATE Info</title>

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -2,6 +2,11 @@
 <html lang="<%= __('lang') %>">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
     <link rel="stylesheet" href="/css/join.css?v=<%= ver %>" />
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <title><%= __('join_title') %></title>

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>URLATE</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
     <link rel="stylesheet" href="/css/globalSocket.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/play.css?v=<%= ver %>" />
     <link rel="shortcut icon" href="/images/favicon.ico" />

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -3,6 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>URLATE 개인정보처리방침</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css">
   <link rel="stylesheet" href="/css/info.css">
   <link rel="shortcut icon" href="/images/favicon.ico">
 <body>

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Test</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
     <link rel="stylesheet" href="/css/globalSocket.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/play.css?v=<%= ver %>" />
     <link rel="shortcut icon" href="/images/favicon.ico" />

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>URLATE Tutorial</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css" />
     <link rel="stylesheet" href="/css/globalSocket.css?v=<%= ver %>" />
     <link rel="stylesheet" href="/css/play.css?v=<%= ver %>" />
     <link rel="shortcut icon" href="/images/favicon.ico" />


### PR DESCRIPTION
## 개요
game/editor/play 및 전체 뷰 대상 성능·보안 감사 결과 적용.

## 변경 사항 (커밋별)

### perf(css) — 폰트 로딩 최적화 `a0d5887`
- CSS 상단 `@import`(Google Fonts·Pretendard·metropolis) 제거 → 각 뷰 `<head>`에서 `preconnect` + `<link>` 병렬 로딩
- Google Fonts `display=swap`, metropolis.css `font-display: swap` 추가 (FOIT 완화)
- 9개 뷰 전체 적용

### perf(game) — 앨범 프리로드 이연 `6d035c4`
- 전체 트랙 앨범 동기 프리로드 → `requestIdleCallback`(폴백 `setTimeout`)으로 초기 렌더 경합 제거

### fix(game) — 무한 루프 제거 `1c58ae7`
- `menuSelected` 랜덤 곡 선택 `while(1)` → 재생 가능 인덱스 배열에서 선택

### security(xss) — 사용자 데이터 이스케이프 `f550d9c`
- `escapeHtml`/`safeUrl`을 `modules/utils.js` 공용 export로 추가, game.js는 동적 import
- 닉네임·프로필 이미지 URL·judge 등 사용자 제어 값 이스케이프, 외부 링크 `rel="noopener noreferrer"`
- 관리자 등록 데이터(tracks·teamProfile·achievement)는 제외

### security(server) — 보안 헤더·캐시 `d9e7926`
- `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` 전역 설정
- 정적 자산 `maxAge: 7d` (`?v=` 캐시버스팅 전제)
- CSP는 인라인 핸들러 리팩터 필요로 제외

### refactor(game) — 인트로 게이트 이전 `ec6c0d8`
- game.ejs head 인라인 `introload` 카운터 → game.js `introReady` 명시 게이트
- `readyState >= HAVE_CURRENT_DATA` 체크로 스크립트 로드 순서 race 제거

## 검증
- `node --check` / eslint / `tsc --noEmit` 통과
- EJS 9개 뷰 컴파일 확인
- 폰트 `@import` 잔여 0, 뷰별 폰트 링크 매칭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)