### PR TITLE
perf(game): 기록 조회를 일괄 요청으로 변경

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -553,20 +553,18 @@ const tracksUpdate = () => {
 
   const defaultRecord = (type) => ({ rank: type == 1 ? "rankL" : "rankQ", record: 0, medal: 0, maxcombo: 0 });
 
-  Promise.all(
-    fetchTargets.map((i) =>
-      fetch(`${api}/record/${tracks[i].fileName}/${username}`, { method: "GET", credentials: "include" })
-        .then((res) => res.json())
-        .then((data) => ({ i, data })),
-    ),
-  )
-    .then((results) => {
-      results.forEach(({ i, data }) => {
+  // 곡마다 따로 묻지 않고 내 기록 전체를 한 번에 받아옵니다.
+  fetch(`${api}/trackRecords/${username}`, { method: "GET", credentials: "include" })
+    .then((res) => res.json())
+    .then((data) => {
+      const records = data.result == "success" ? data.records : {};
+      fetchTargets.forEach((i) => {
         trackRecords[i] = [defaultRecord(tracks[i].type), defaultRecord(tracks[i].type), defaultRecord(tracks[i].type)];
-        if (data.result == "success") {
+        const results = records[tracks[i].fileName];
+        if (results && results.length) {
           for (let j = 0; j < 3; j++) {
-            if (data.results[j] != undefined) {
-              const value = data.results[j];
+            if (results[j] != undefined) {
+              const value = results[j];
               const rankEl = document.getElementsByClassName("ranks")[i];
               rankEl.className = `ranks rank${value.rank}`;
               trackRecords[i][value.difficulty - 1] = {
@@ -1224,16 +1222,17 @@ const profileUpdate = async (uid, isMe) => {
       document.getElementsByClassName("profileStatValue")[5].textContent = "-";
       document.getElementById("profileRecentPlay").innerHTML = `<span class="nothingHere">${nothingHere}</span>`;
     } else {
-      const recentResults = await Promise.all(recentPlay.map((id) => fetch(`${api}/record/${id}`, { method: "GET", credentials: "include" }).then((res) => res.json())));
+      // 기록 id마다 따로 묻지 않고 최근 플레이 목록을 한 번에 받아옵니다.
+      const recentRes = await fetch(`${api}/recentPlays/${uid}`, { method: "GET", credentials: "include" }).then((res) => res.json());
+      const recentResults = recentRes.result == "success" ? recentRes.results : [];
       let recentHTML = "";
       for (let i = 0; i < recentResults.length; i++) {
-        const res = recentResults[i];
-        if (res.result == "success") {
+        const data = recentResults[i];
+        if (data) {
           if (i == 0) {
-            const recentDate = new Date(res.results[0].date);
+            const recentDate = new Date(data.date);
             document.getElementsByClassName("profileStatValue")[5].textContent = `${recentDate.toLocaleDateString()}`;
           }
-          const data = res.results[0];
           const song = tracks.find((e) => e.fileName == data.filename);
           const difficulty = JSON.parse(song.difficulty)[data.difficulty - 1];
           recentHTML += `<div class="playContainer">


### PR DESCRIPTION
## 배경

곡 선택 화면과 프로필이 기록을 건건이 조회하고 있었습니다. 요청 수가 데이터 수에 비례해 늘어나는 구조입니다.

- `tracksUpdate()` 가 **곡 수만큼** `/record/:fileName/:username` 을 병렬 발사
- 프로필이 **최근 플레이 수만큼** `/record/:index` 를 병렬 발사

특히 곡 선택 쪽은 정렬을 바꿀 때마다 `tracksUpdate()` 가 다시 불리므로, 사용자가 화면을 만질 때마다 반복해서 발생하던 부하입니다.

백엔드에 캐시를 붙여 요청당 DB 부하는 없앴지만 HTTP 왕복 횟수 자체는 그대로 남아 있어, 이 PR에서 요청 수를 줄입니다.

## 변경 사항

| 기존 | 변경 후 | 요청 수 |
|---|---|---|
| 곡별 `/record/:fileName/:username` | `/trackRecords/:username` | **N → 1** |
| id별 `/record/:index` | `/recentPlays/:uid` | **10 → 1** |

`public/js/game.js` 만 수정했습니다.

## 화면 동작

이전과 동일합니다. 기존 코드와 새 코드를 실제 백엔드에 나란히 붙여 돌린 뒤 결과를 비교해 확인했습니다.

- 새 코드가 만드는 `trackRecords` 배열이 기존과 완전히 동일 (`deepStrictEqual`)
- 랭크 아이콘 `className` 과 잠금 클래스 부여 상태가 동일
- 기록이 있는 잠금 곡은 잠기지 않고, 기록이 없는 잠금 곡은 잠김
- 숨김 곡(`type 3`)은 기존과 같이 건드리지 않음
- 다른 유저의 기록과 `isBest=0` 인 과거 기록이 섞이지 않음
- 최근 플레이의 데이터와 **순서(최신순)** 가 기존과 동일하고, 존재하지 않는 기록 id는 제외됨

`eslint`, `prettier --check` 모두 통과합니다.

## 배포 순서

이 PR은 백엔드의 신규 엔드포인트(`/trackRecords/:nickname`, `/recentPlays/:uid`)에 의존합니다. **백엔드 PR([HyeokjinKang/URLATE-v3l-backend#26](https://github.com/HyeokjinKang/URLATE-v3l-backend/pull/26))을 먼저 배포**해 주세요. 반대 순서로 배포하면 곡 선택 화면의 기록과 프로필의 최근 플레이가 표시되지 않습니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7hKt9vaekfDN8Ci7gmTtS)_