### PR TITLE
fix: 로그인이 필요한 페이지를 서버측에서 검사

### DIFF
--- a/config/config_example.json
+++ b/config/config_example.json
@@ -9,6 +9,7 @@
     "ignoredImageURL": ["cdn.example.com", "googleusercontent"],
     "mode": "production",
     "port": 3000,
-    "trustProxy": 1
+    "trustProxy": 1,
+    "cookieDomain": ".example.com"
   }
 }

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -8,6 +8,7 @@
     "secretKey": "Something Random",
     "ignoredImageURL": ["cdn.example.com", "googleusercontent"],
     "mode": "production",
-    "port": 3000
+    "port": 3000,
+    "trustProxy": 1
   }
 }

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -10,6 +10,7 @@
     "mode": "production",
     "port": 3000,
     "trustProxy": 1,
-    "cookieDomain": ".example.com"
+    "sessionCookie": "urlate",
+    "cookieDomain": "example.com"
   }
 }

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -9,7 +9,7 @@
     "ignoredImageURL": ["cdn.example.com", "googleusercontent"],
     "mode": "production",
     "port": 3000,
-    "trustProxy": 1,
+    "trustProxy": 2,
     "sessionCookie": "urlate",
     "cookieDomain": "example.com"
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -168,7 +168,6 @@
   "index_logoAlt": "Avoid & Get on the tempo, URLATE",
   "login_failed": "Login Failed!",
   "login_error": "Login Error!",
-  "shutdowned_alert": "Minors under the age of 16 are restricted from playing between midnight and 6 AM.",
   "join_title": "Welcome to URLATE!",
   "join": "Register",
   "join_desc": "Please choose a nickname.",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -107,7 +107,6 @@
   "skip_tutorial": "튜토리얼을 건너뛸래요",
   "confirm_exit_tutorial": "튜토리얼을 건너뛰실래요? 설정에서 튜토리얼을 다시 진행할 수 있습니다.",
   "pattern_error": "패턴을 불러오는 중 오류가 발생했습니다.",
-  "shutdowned_alert": "만 16세 미만의 미성년자는 0시부터 6시까지 게임 이용이 제한됩니다.",
   "medal_description": "게임 플레이를 통해 얻을 수 있는 메달입니다. 차례대로 AP(All Perfect), FC(Full Combo), 클리어를 의미합니다.",
   "retry_tutorial": "튜토리얼 다시 시작",
   "move": "이동",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cookie-parser": "^1.4.7",
     "ejs": "^3.1.10",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "i18n": "^0.15.3",
     "multer": "^2.2.0",
     "node-fetch": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.6.2
+        version: 8.6.2(express@5.2.1)
       i18n:
         specifier: ^0.15.3
         version: 0.15.3
@@ -897,6 +900,12 @@ packages:
   event-stream@3.3.4:
     resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
 
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -1072,6 +1081,10 @@ packages:
 
   inversify@6.1.4:
     resolution: {integrity: sha512-PbxrZH/gTa1fpPEEGAjJQzK8tKMIp5gRg6EFNJlCtzUcycuNdmhv3uk5P8Itm/RIjgHJO16oQRLo9IHzQN51bA==}
+
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2575,6 +2588,14 @@ snapshots:
       stream-combiner: 0.0.4
       through: 2.3.8
 
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -2779,6 +2800,8 @@ snapshots:
       '@inversifyjs/core': 1.3.4(reflect-metadata@0.2.2)
     transitivePeerDependencies:
       - reflect-metadata
+
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -165,46 +165,22 @@ const settingApply = () => {
 };
 
 document.addEventListener("DOMContentLoaded", () => {
-  fetch(`${api}/auth/status`, {
+  // The server already refused to serve this page to a visitor without editor access.
+  fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
   })
     .then((res) => res.json())
     .then((data) => {
-      if (data.status == "Not authorized") {
-        window.location.href = `${url}/authorize`;
-      } else if (data.status == "Not registered") {
-        window.location.href = `${url}/join`;
-      } else if (data.status == "Not logined") {
-        window.location.href = url;
-      } else if (data.status == "Not authenticated") {
-        window.location.href = `${url}/authentication`;
-      } else if (data.status == "Not authenticated(adult)") {
-        window.location.href = `${url}/authentication?adult=1`;
-      } else if (data.status == "Shutdowned") {
-        window.location.href = `${api}/auth/logout?redirect=true&shutdowned=true`;
+      if (data.result == "success") {
+        data = data.user;
+        userName = data.nickname;
+        settings = JSON.parse(data.settings);
+        initialize(true);
+        settingApply();
       } else {
-        fetch(`${api}/user`, {
-          method: "GET",
-          credentials: "include",
-        })
-          .then((res) => res.json())
-          .then((data) => {
-            if (data.result == "success") {
-              data = data.user;
-              userName = data.nickname;
-              settings = JSON.parse(data.settings);
-              initialize(true);
-              settingApply();
-            } else {
-              alert(`Error occured.\n${data.description}`);
-              console.error(`Error occured.\n${data.description}`);
-            }
-          })
-          .catch((error) => {
-            alert(`Error occured.\n${error}`);
-            console.error(`Error occured.\n${error}`);
-          });
+        alert(`Error occured.\n${data.description}`);
+        console.error(`Error occured.\n${data.description}`);
       }
     })
     .catch((error) => {

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -179,8 +179,8 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        alert(`Error occured.\n${data.description}`);
-        console.error(`Error occured.\n${data.description}`);
+        // The session is no longer usable, so sign out instead of leaving a dead page.
+        window.location.href = "/logout";
       }
     })
     .catch((error) => {

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -165,7 +165,7 @@ const settingApply = () => {
 };
 
 document.addEventListener("DOMContentLoaded", () => {
-  // The server already refused to serve this page to a visitor without editor access.
+  // Signed-out visitors were already turned away by the server gate.
   fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
@@ -179,7 +179,7 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        // The session is no longer usable, so sign out instead of leaving a dead page.
+        // The session is gone; sign out instead of leaving a dead page.
         window.location.href = "/logout";
       }
     })

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1362,7 +1362,7 @@ const langChanged = (e) => {
 
 // eslint-disable-next-line no-unused-vars
 const logout = () => {
-  window.location.href = `${api}/auth/logout?redirect=true`;
+  window.location.href = "/logout";
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -430,69 +430,48 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
 
-  fetch(`${api}/auth/status`, {
+  // The server already refused to serve this page to a signed-out visitor.
+  fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
   })
     .then((res) => res.json())
     .then((data) => {
-      if (data.status == "Not registered") {
-        window.location.href = `${url}/join`;
-      } else if (data.status == "Not logined") {
-        window.location.href = url;
-      } else if (data.status == "Shutdowned") {
-        window.location.href = `${api}/auth/logout?redirect=true&shutdowned=true`;
-      } else {
-        fetch(`${api}/user`, {
+      if (data.result == "success") {
+        data = data.user;
+        settings = JSON.parse(data.settings);
+        username = data.nickname;
+        userid = data.userid;
+        tutorial = data.tutorial;
+        picture = data.picture;
+        document.getElementById("profilePic").src = picture;
+        if (data.explicit % 2 == 1) document.getElementById("profilePic").classList.add("blur");
+        document.getElementById("name").textContent = username;
+        document.getElementById("optionName").textContent = username;
+        langSelector.value = lang;
+        skins = JSON.parse(data.skins);
+        for (let i = 0; i < skins.length; i++) {
+          let option = document.createElement("option");
+          option.appendChild(document.createTextNode(skins[i]));
+          skinSelector.appendChild(option);
+        }
+        settingApply();
+        fetch(`${api}/tracks`, {
           method: "GET",
           credentials: "include",
         })
           .then((res) => res.json())
           .then((data) => {
             if (data.result == "success") {
-              data = data.user;
-              settings = JSON.parse(data.settings);
-              username = data.nickname;
-              userid = data.userid;
-              tutorial = data.tutorial;
-              picture = data.picture;
-              document.getElementById("profilePic").src = picture;
-              if (data.explicit % 2 == 1) document.getElementById("profilePic").classList.add("blur");
-              document.getElementById("name").textContent = username;
-              document.getElementById("optionName").textContent = username;
-              langSelector.value = lang;
-              skins = JSON.parse(data.skins);
-              for (let i = 0; i < skins.length; i++) {
-                let option = document.createElement("option");
-                option.appendChild(document.createTextNode(skins[i]));
-                skinSelector.appendChild(option);
-              }
-              settingApply();
-              fetch(`${api}/tracks`, {
-                method: "GET",
-                credentials: "include",
-              })
-                .then((res) => res.json())
-                .then((data) => {
-                  if (data.result == "success") {
-                    tracks = data.tracks;
-                    tracks.sort(sortAsName);
-                    tracksUpdate();
-                    Howler.volume(settings.sound.volume.master * settings.sound.volume.music);
-                    intro1video.volume = settings.sound.volume.master * settings.sound.volume.music;
-                    intro2video.volume = settings.sound.volume.master * settings.sound.volume.music;
-                  } else {
-                    alert("Failed to load song list.");
-                    console.error("Failed to load song list.");
-                  }
-                })
-                .catch((error) => {
-                  alert(`Error occured.\n${error}`);
-                  console.error(`Error occured.\n${error}`);
-                  location.reload();
-                });
+              tracks = data.tracks;
+              tracks.sort(sortAsName);
+              tracksUpdate();
+              Howler.volume(settings.sound.volume.master * settings.sound.volume.music);
+              intro1video.volume = settings.sound.volume.master * settings.sound.volume.music;
+              intro2video.volume = settings.sound.volume.master * settings.sound.volume.music;
             } else {
-              alert(`Error occured.\n${data.description}`);
+              alert("Failed to load song list.");
+              console.error("Failed to load song list.");
             }
           })
           .catch((error) => {
@@ -500,6 +479,8 @@ document.addEventListener("DOMContentLoaded", () => {
             console.error(`Error occured.\n${error}`);
             location.reload();
           });
+      } else {
+        alert(`Error occured.\n${data.description}`);
       }
     })
     .catch((error) => {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -480,7 +480,8 @@ document.addEventListener("DOMContentLoaded", () => {
             location.reload();
           });
       } else {
-        alert(`Error occured.\n${data.description}`);
+        // The session is no longer usable, so sign out instead of leaving a dead page.
+        window.location.href = "/logout";
       }
     })
     .catch((error) => {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -430,7 +430,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
 
-  // The server already refused to serve this page to a signed-out visitor.
+  // Signed-out visitors were already turned away by the server gate.
   fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
@@ -480,7 +480,7 @@ document.addEventListener("DOMContentLoaded", () => {
             location.reload();
           });
       } else {
-        // The session is no longer usable, so sign out instead of leaving a dead page.
+        // The session is gone; sign out instead of leaving a dead page.
         window.location.href = "/logout";
       }
     })

--- a/public/js/join.js
+++ b/public/js/join.js
@@ -10,8 +10,6 @@ document.addEventListener("DOMContentLoaded", () => {
         window.location.href = `${projectUrl}/game`;
       } else if (data.status == "Not logined") {
         window.location.href = projectUrl;
-      } else if (data.status == "Shutdowned") {
-        window.location.href = `${api}/auth/logout?redirect=true&shutdowned=true`;
       }
       if (nameReg.test(data.tempName)) {
         document.getElementById("nickname").value = data.tempName;

--- a/public/js/play.js
+++ b/public/js/play.js
@@ -147,41 +147,23 @@ document.addEventListener("DOMContentLoaded", () => {
       alert(`Error occured.\n${error}`);
       console.error(`Error occured.\n${error}`);
     });
-  fetch(`${api}/auth/status`, {
+  // The server already refused to serve this page to a signed-out visitor.
+  fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
   })
     .then((res) => res.json())
     .then((data) => {
-      if (data.status == "Not registered") {
-        window.location.href = `${url}/join`;
-      } else if (data.status == "Not logined") {
-        window.location.href = url;
-      } else if (data.status == "Shutdowned") {
-        window.location.href = `${api}/auth/logout?redirect=true&shutdowned=true`;
+      if (data.result == "success") {
+        data = data.user;
+        userName = data.nickname;
+        userid = data.userid;
+        settings = JSON.parse(data.settings);
+        initialize(true);
+        settingApply();
       } else {
-        fetch(`${api}/user`, {
-          method: "GET",
-          credentials: "include",
-        })
-          .then((res) => res.json())
-          .then((data) => {
-            if (data.result == "success") {
-              data = data.user;
-              userName = data.nickname;
-              userid = data.userid;
-              settings = JSON.parse(data.settings);
-              initialize(true);
-              settingApply();
-            } else {
-              alert(`Error occured.\n${data.description}`);
-              console.error(`Error occured.\n${data.description}`);
-            }
-          })
-          .catch((error) => {
-            alert(`Error occured.\n${error}`);
-            console.error(`Error occured.\n${error}`);
-          });
+        alert(`Error occured.\n${data.description}`);
+        console.error(`Error occured.\n${data.description}`);
       }
     })
     .catch((error) => {

--- a/public/js/play.js
+++ b/public/js/play.js
@@ -147,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
       alert(`Error occured.\n${error}`);
       console.error(`Error occured.\n${error}`);
     });
-  // The server already refused to serve this page to a signed-out visitor.
+  // Signed-out visitors were already turned away by the server gate.
   fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
@@ -162,7 +162,7 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        // The session is no longer usable, so sign out instead of leaving a dead page.
+        // The session is gone; sign out instead of leaving a dead page.
         window.location.href = "/logout";
       }
     })

--- a/public/js/play.js
+++ b/public/js/play.js
@@ -162,8 +162,8 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        alert(`Error occured.\n${data.description}`);
-        console.error(`Error occured.\n${data.description}`);
+        // The session is no longer usable, so sign out instead of leaving a dead page.
+        window.location.href = "/logout";
       }
     })
     .catch((error) => {

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -143,39 +143,21 @@ document.addEventListener("DOMContentLoaded", () => {
       alert(`Error occured.\n${error}`);
       console.error(`Error occured.\n${error}`);
     });
-  fetch(`${api}/auth/status`, {
+  // The server already refused to serve this page to a signed-out visitor.
+  fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
   })
     .then((res) => res.json())
     .then((data) => {
-      if (data.status == "Not registered") {
-        window.location.href = `${url}/join`;
-      } else if (data.status == "Not logined") {
-        window.location.href = url;
-      } else if (data.status == "Shutdowned") {
-        window.location.href = `${api}/auth/logout?redirect=true&shutdowned=true`;
+      if (data.result == "success") {
+        data = data.user;
+        settings = JSON.parse(data.settings);
+        initialize(true);
+        settingApply();
       } else {
-        fetch(`${api}/user`, {
-          method: "GET",
-          credentials: "include",
-        })
-          .then((res) => res.json())
-          .then((data) => {
-            if (data.result == "success") {
-              data = data.user;
-              settings = JSON.parse(data.settings);
-              initialize(true);
-              settingApply();
-            } else {
-              alert(`Error occured.\n${data.description}`);
-              console.error(`Error occured.\n${data.description}`);
-            }
-          })
-          .catch((error) => {
-            alert(`Error occured.\n${error}`);
-            console.error(`Error occured.\n${error}`);
-          });
+        alert(`Error occured.\n${data.description}`);
+        console.error(`Error occured.\n${data.description}`);
       }
     })
     .catch((error) => {

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -156,8 +156,8 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        alert(`Error occured.\n${data.description}`);
-        console.error(`Error occured.\n${data.description}`);
+        // The session is no longer usable, so sign out instead of leaving a dead page.
+        window.location.href = "/logout";
       }
     })
     .catch((error) => {

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -143,7 +143,7 @@ document.addEventListener("DOMContentLoaded", () => {
       alert(`Error occured.\n${error}`);
       console.error(`Error occured.\n${error}`);
     });
-  // The server already refused to serve this page to a signed-out visitor.
+  // Signed-out visitors were already turned away by the server gate.
   fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
@@ -156,7 +156,7 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        // The session is no longer usable, so sign out instead of leaving a dead page.
+        // The session is gone; sign out instead of leaving a dead page.
         window.location.href = "/logout";
       }
     })

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -125,7 +125,7 @@ let UIFontNormal = "";
 const albumImg = new Image();
 
 document.addEventListener("DOMContentLoaded", () => {
-  // The server already refused to serve this page to a signed-out visitor.
+  // Signed-out visitors were already turned away by the server gate.
   fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
@@ -138,7 +138,7 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        // The session is no longer usable, so sign out instead of leaving a dead page.
+        // The session is gone; sign out instead of leaving a dead page.
         window.location.href = "/logout";
       }
     })

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -138,8 +138,8 @@ document.addEventListener("DOMContentLoaded", () => {
         initialize(true);
         settingApply();
       } else {
-        alert(`Error occured.\n${data.description}`);
-        console.error(`Error occured.\n${data.description}`);
+        // The session is no longer usable, so sign out instead of leaving a dead page.
+        window.location.href = "/logout";
       }
     })
     .catch((error) => {

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -125,39 +125,21 @@ let UIFontNormal = "";
 const albumImg = new Image();
 
 document.addEventListener("DOMContentLoaded", () => {
-  fetch(`${api}/auth/status`, {
+  // The server already refused to serve this page to a signed-out visitor.
+  fetch(`${api}/user`, {
     method: "GET",
     credentials: "include",
   })
     .then((res) => res.json())
     .then((data) => {
-      if (data.status == "Not registered") {
-        window.location.href = `${url}/join`;
-      } else if (data.status == "Not logined") {
-        window.location.href = url;
-      } else if (data.status == "Shutdowned") {
-        window.location.href = `${api}/auth/logout?redirect=true&shutdowned=true`;
+      if (data.result == "success") {
+        data = data.user;
+        settings = JSON.parse(data.settings);
+        initialize(true);
+        settingApply();
       } else {
-        fetch(`${api}/user`, {
-          method: "GET",
-          credentials: "include",
-        })
-          .then((res) => res.json())
-          .then((data) => {
-            if (data.result == "success") {
-              data = data.user;
-              settings = JSON.parse(data.settings);
-              initialize(true);
-              settingApply();
-            } else {
-              alert(`Error occured.\n${data.description}`);
-              console.error(`Error occured.\n${data.description}`);
-            }
-          })
-          .catch((error) => {
-            alert(`Error occured.\n${error}`);
-            console.error(`Error occured.\n${error}`);
-          });
+        alert(`Error occured.\n${data.description}`);
+        console.error(`Error occured.\n${data.description}`);
       }
     })
     .catch((error) => {

--- a/public/modules/socket.js
+++ b/public/modules/socket.js
@@ -1,4 +1,4 @@
-/* global io, iziToast, game, api, lang, alias, socketi18n */
+/* global io, iziToast, game, lang, alias, socketi18n */
 const body = document.querySelector("body");
 let isErrorOccured = false;
 let achievementCount = 0;
@@ -30,7 +30,7 @@ socket.on("connect", () => {
 socket.on("disconnect", (reason) => {
   if (reason === "io server disconnect") {
     alert(socketi18n.error);
-    window.location.href = `${api}/auth/logout?redirect=true`; // Session error, need to relogin
+    window.location.href = "/logout"; // Session error, need to relogin
   } else if (reason === "io client disconnect") return;
   console.error("[Socket.IO] Disconnected from server");
   iziToast.warning({
@@ -61,13 +61,13 @@ socket.on("connect_error", () => {
 socket.on("connection:conflict", () => {
   socket.disconnect();
   alert(socketi18n.conflict);
-  window.location.href = `${api}/auth/logout?redirect=true`;
+  window.location.href = "/logout";
 });
 
 socket.on("connection:unauthorized", () => {
   socket.disconnect();
   alert(socketi18n.unauthorized);
-  window.location.href = `${api}/auth/logout?redirect=true`;
+  window.location.href = "/logout";
 });
 
 socket.on("achievement", (data) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import cookieParser from "cookie-parser";
 import express, { NextFunction, Request, Response } from "express";
+import rateLimit from "express-rate-limit";
 import i18n from "./i18n";
 import multer from "multer";
 import path from "path";
@@ -33,6 +34,11 @@ const API_TIMEOUT_MS = 5000;
 
 const app = express();
 app.locals.pretty = true;
+
+// The rate limiter below keys on the client address, which arrives in
+// X-Forwarded-For from the CDN and reverse proxy in front. Trusting more hops
+// than actually exist would let a caller spoof it, so the count is configurable.
+app.set("trust proxy", config.project.trustProxy ?? 1);
 
 app.set("view engine", "ejs");
 app.set("views", __dirname + "/../views");
@@ -124,6 +130,20 @@ const writeCachedStatus = (key: string, status: string) => {
 };
 
 /**
+ * Bound how much backend traffic one address can generate through the gate.
+ *
+ * A cache miss costs a lookup against the backend, and a caller can force a miss
+ * on every request just by varying the cookie it sends. One limiter is shared by
+ * the gated pages, so the budget covers their combined load.
+ */
+const gateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
  * Gate the pages that only make sense for a signed-in player.
  *
  * The status -> destination mapping is the one each page used to run in the
@@ -167,7 +187,7 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-app.get("/game", requireAuth, async (req, res) => {
+app.get("/game", gateLimiter, requireAuth, async (req, res) => {
   res.render("game", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -177,7 +197,7 @@ app.get("/game", requireAuth, async (req, res) => {
   });
 });
 
-app.get("/editor", requireAuth, async (req, res) => {
+app.get("/editor", gateLimiter, requireAuth, async (req, res) => {
   res.render("editor", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -187,7 +207,7 @@ app.get("/editor", requireAuth, async (req, res) => {
   });
 });
 
-app.get("/test", requireAuth, async (req, res) => {
+app.get("/test", gateLimiter, requireAuth, async (req, res) => {
   res.render("test", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -197,7 +217,7 @@ app.get("/test", requireAuth, async (req, res) => {
   });
 });
 
-app.get("/play", requireAuth, async (req, res) => {
+app.get("/play", gateLimiter, requireAuth, async (req, res) => {
   res.render("play", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -207,7 +227,7 @@ app.get("/play", requireAuth, async (req, res) => {
   });
 });
 
-app.get("/tutorial", requireAuth, async (req, res) => {
+app.get("/tutorial", gateLimiter, requireAuth, async (req, res) => {
   res.render("tutorial", {
     cdn: config.project.cdn,
     url: config.project.url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,20 @@ const gateLimiter = rateLimit({
 });
 
 /**
+ * Logout gets its own budget rather than sharing the one above.
+ *
+ * It costs nothing on the backend, so it does not belong to the gate's budget,
+ * and keeping it separate means a burst of page loads can never leave a visitor
+ * unable to sign out. Signing out is idempotent and rare, so this can be small.
+ */
+const logoutLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
  * Gate the pages that only make sense for a signed-in player.
  *
  * The status -> destination mapping is the one each page used to run in the
@@ -201,7 +215,7 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
  * window either way: with the entry gone the next gated request has to ask the
  * backend again, whether or not the cookie survived.
  */
-app.get("/logout", (req, res) => {
+app.get("/logout", logoutLimiter, (req, res) => {
   if (req.headers.cookie) authStatusCache.delete(authCacheKey(req.headers.cookie));
 
   for (const name of Object.keys(req.cookies ?? {})) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,8 +36,9 @@ const app = express();
 app.locals.pretty = true;
 
 // Rate limiting keys on the client address, which arrives via X-Forwarded-For.
-// Trusting more hops than actually exist would let a caller spoof it.
-app.set("trust proxy", config.project.trustProxy ?? 1);
+// Two hops answer for the CDN and the reverse proxy in front; trusting more
+// than actually exist would let a caller spoof the address by sending it.
+app.set("trust proxy", config.project.trustProxy ?? 2);
 
 app.set("view engine", "ejs");
 app.set("views", __dirname + "/../views");

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import sharp from "sharp";
 import { logger } from "./logger";
 import { errorHandler } from "./middleware";
 import { URL } from "url";
+import { createHash } from "crypto";
 
 let branch;
 exec("git branch --show-current", (err, stdout, stderr) => {
@@ -73,6 +74,63 @@ app.get("/join", (req, res) => {
   res.render("join", { api: config.project.api, ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version, url: config.project.url });
 });
 
+const baseRedirects: Record<string, string> = {
+  "Not registered": `${config.project.url}/join`,
+  "Not logined": config.project.url,
+  Shutdowned: `${config.project.api}/auth/logout?redirect=true&shutdowned=true`,
+};
+
+// The editor is gated on more than a login: authorization and identity verification.
+const editorRedirects: Record<string, string> = {
+  "Not authorized": `${config.project.url}/authorize`,
+  "Not authenticated": `${config.project.url}/authentication`,
+  "Not authenticated(adult)": `${config.project.url}/authentication?adult=1`,
+};
+
+// Every status that sends the visitor somewhere else on at least one gated page.
+const gatedStatuses = new Set([...Object.keys(baseRedirects), ...Object.keys(editorRedirects)]);
+
+/**
+ * Short-lived cache of the backend's auth status, keyed by the caller's cookies.
+ *
+ * Gated pages carry `no-store`, so the CDN in front cannot absorb them and every
+ * navigation reaches this process. Without this cache each one would also cost a
+ * round trip to the backend.
+ *
+ * Only statuses that let the visitor through are stored. Caching a gated status
+ * would trap a user who just resolved it: finishing signup sends the browser to
+ * /game, and a stale "Not registered" would bounce it back to /join, which sends
+ * it to /game again. Gated statuses are rare and short-lived, so they are always
+ * re-checked; the cache exists for the steady state of an ordinary player moving
+ * between pages.
+ */
+const AUTH_CACHE_TTL_MS = 30 * 1000;
+const AUTH_CACHE_MAX_ENTRIES = 5000;
+const authStatusCache = new Map<string, { status: string; expiresAt: number }>();
+
+// Hashed so live session cookies are not held in memory for the TTL.
+const authCacheKey = (cookie: string) => createHash("sha256").update(cookie).digest("hex");
+
+const readCachedStatus = (key: string): string | null => {
+  const entry = authStatusCache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    authStatusCache.delete(key);
+    return null;
+  }
+  return entry.status;
+};
+
+const writeCachedStatus = (key: string, status: string) => {
+  if (gatedStatuses.has(status)) return;
+  // Re-insert so the cap evicts the least recently written entry.
+  authStatusCache.delete(key);
+  if (authStatusCache.size >= AUTH_CACHE_MAX_ENTRIES) {
+    authStatusCache.delete(authStatusCache.keys().next().value);
+  }
+  authStatusCache.set(key, { status, expiresAt: Date.now() + AUTH_CACHE_TTL_MS });
+};
+
 /**
  * Gate the pages that only make sense for a signed-in player.
  *
@@ -82,17 +140,21 @@ app.get("/join", (req, res) => {
  * JavaScript or dropping the redirect.
  */
 const requireAuth = (extraRedirects: Record<string, string> = {}) => {
-  const redirects: Record<string, string> = {
-    "Not registered": `${config.project.url}/join`,
-    "Not logined": config.project.url,
-    Shutdowned: `${config.project.api}/auth/logout?redirect=true&shutdowned=true`,
-    ...extraRedirects,
-  };
+  const redirects: Record<string, string> = { ...baseRedirects, ...extraRedirects };
 
   return async (req: Request, res: Response, next: NextFunction) => {
-    // The response depends on the session, so it must never be cached.
+    // The response depends on the session, so neither the CDN nor the browser may cache it.
     res.setHeader("Cache-Control", "no-store");
     if (!req.headers.cookie) return res.redirect(redirects["Not logined"]);
+
+    const key = authCacheKey(req.headers.cookie);
+    const cached = readCachedStatus(key);
+    if (cached !== null) {
+      const redirect = redirects[cached];
+      if (redirect) return res.redirect(redirect);
+      return next();
+    }
+
     try {
       const response = await fetch(`${config.project.api}/auth/status`, {
         method: "GET",
@@ -104,7 +166,9 @@ const requireAuth = (extraRedirects: Record<string, string> = {}) => {
       });
       if (!response.ok) return res.redirect(config.project.url);
       const data: any = await response.json();
-      const redirect = redirects[data.status];
+      const status = String(data.status);
+      writeCachedStatus(key, status);
+      const redirect = redirects[status];
       if (redirect) return res.redirect(redirect);
       next();
     } catch (err) {
@@ -113,13 +177,6 @@ const requireAuth = (extraRedirects: Record<string, string> = {}) => {
       res.redirect(config.project.url);
     }
   };
-};
-
-// The editor is gated on more than a login: authorization and identity verification.
-const editorRedirects = {
-  "Not authorized": `${config.project.url}/authorize`,
-  "Not authenticated": `${config.project.url}/authentication`,
-  "Not authenticated(adult)": `${config.project.url}/authentication?adult=1`,
 };
 
 app.get("/game", requireAuth(), async (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,21 +74,13 @@ app.get("/join", (req, res) => {
   res.render("join", { api: config.project.api, ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version, url: config.project.url });
 });
 
-const baseRedirects: Record<string, string> = {
+const authRedirects: Record<string, string> = {
   "Not registered": `${config.project.url}/join`,
   "Not logined": config.project.url,
-  Shutdowned: `${config.project.api}/auth/logout?redirect=true&shutdowned=true`,
 };
 
-// The editor is gated on more than a login: authorization and identity verification.
-const editorRedirects: Record<string, string> = {
-  "Not authorized": `${config.project.url}/authorize`,
-  "Not authenticated": `${config.project.url}/authentication`,
-  "Not authenticated(adult)": `${config.project.url}/authentication?adult=1`,
-};
-
-// Every status that sends the visitor somewhere else on at least one gated page.
-const gatedStatuses = new Set([...Object.keys(baseRedirects), ...Object.keys(editorRedirects)]);
+// Statuses that send the visitor elsewhere instead of rendering the page.
+const gatedStatuses = new Set(Object.keys(authRedirects));
 
 /**
  * Short-lived cache of the backend's auth status, keyed by the caller's cookies.
@@ -139,47 +131,43 @@ const writeCachedStatus = (key: string, status: string) => {
  * receives the page at all, so the check can no longer be skipped by disabling
  * JavaScript or dropping the redirect.
  */
-const requireAuth = (extraRedirects: Record<string, string> = {}) => {
-  const redirects: Record<string, string> = { ...baseRedirects, ...extraRedirects };
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  // The response depends on the session, so neither the CDN nor the browser may cache it.
+  res.setHeader("Cache-Control", "no-store");
+  if (!req.headers.cookie) return res.redirect(authRedirects["Not logined"]);
 
-  return async (req: Request, res: Response, next: NextFunction) => {
-    // The response depends on the session, so neither the CDN nor the browser may cache it.
-    res.setHeader("Cache-Control", "no-store");
-    if (!req.headers.cookie) return res.redirect(redirects["Not logined"]);
+  const key = authCacheKey(req.headers.cookie);
+  const cached = readCachedStatus(key);
+  if (cached !== null) {
+    const redirect = authRedirects[cached];
+    if (redirect) return res.redirect(redirect);
+    return next();
+  }
 
-    const key = authCacheKey(req.headers.cookie);
-    const cached = readCachedStatus(key);
-    if (cached !== null) {
-      const redirect = redirects[cached];
-      if (redirect) return res.redirect(redirect);
-      return next();
-    }
-
-    try {
-      const response = await fetch(`${config.project.api}/auth/status`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: req.headers.cookie,
-        },
-        signal: AbortSignal.timeout(API_TIMEOUT_MS),
-      });
-      if (!response.ok) return res.redirect(config.project.url);
-      const data: any = await response.json();
-      const status = String(data.status);
-      writeCachedStatus(key, status);
-      const redirect = redirects[status];
-      if (redirect) return res.redirect(redirect);
-      next();
-    } catch (err) {
-      // Fail closed: an unreachable backend must not open the gate.
-      logger.warn("Failed to check auth status", { path: req.path, error: err });
-      res.redirect(config.project.url);
-    }
-  };
+  try {
+    const response = await fetch(`${config.project.api}/auth/status`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: req.headers.cookie,
+      },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    if (!response.ok) return res.redirect(config.project.url);
+    const data: any = await response.json();
+    const status = String(data.status);
+    writeCachedStatus(key, status);
+    const redirect = authRedirects[status];
+    if (redirect) return res.redirect(redirect);
+    next();
+  } catch (err) {
+    // Fail closed: an unreachable backend must not open the gate.
+    logger.warn("Failed to check auth status", { path: req.path, error: err });
+    res.redirect(config.project.url);
+  }
 };
 
-app.get("/game", requireAuth(), async (req, res) => {
+app.get("/game", requireAuth, async (req, res) => {
   res.render("game", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -189,7 +177,7 @@ app.get("/game", requireAuth(), async (req, res) => {
   });
 });
 
-app.get("/editor", requireAuth(editorRedirects), async (req, res) => {
+app.get("/editor", requireAuth, async (req, res) => {
   res.render("editor", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -199,7 +187,7 @@ app.get("/editor", requireAuth(editorRedirects), async (req, res) => {
   });
 });
 
-app.get("/test", requireAuth(), async (req, res) => {
+app.get("/test", requireAuth, async (req, res) => {
   res.render("test", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -209,7 +197,7 @@ app.get("/test", requireAuth(), async (req, res) => {
   });
 });
 
-app.get("/play", requireAuth(), async (req, res) => {
+app.get("/play", requireAuth, async (req, res) => {
   res.render("play", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -219,7 +207,7 @@ app.get("/play", requireAuth(), async (req, res) => {
   });
 });
 
-app.get("/tutorial", requireAuth(), async (req, res) => {
+app.get("/tutorial", requireAuth, async (req, res) => {
   res.render("tutorial", {
     cdn: config.project.cdn,
     url: config.project.url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,20 +209,21 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
  * there. Without it a visitor keeps passing the gate on a cached status until
  * it expires, and the pages they get are useless because the session is gone.
  *
- * Clearing a cookie only works for names this host can write, so a cookie the
- * backend scoped to its own host stays; `cookieDomain` covers the common case
- * of a session shared across subdomains. The cache eviction is what closes the
- * window either way: with the entry gone the next gated request has to ask the
- * backend again, whether or not the cookie survived.
+ * `sessionCookie` and `cookieDomain` name the backend's session cookie, so they
+ * have to match what it sets. If they don't, the browser keeps the cookie and
+ * only the cache eviction takes effect -- which is what closes the window in
+ * either case, since the next gated request then has to ask the backend again.
+ *
+ * The redirect at the end keeps the backend's own logout in the flow. It is a
+ * GET route that checks the request origin, and it reads that origin from the
+ * Referer, which survives this hop.
  */
 app.get("/logout", logoutLimiter, (req, res) => {
   if (req.headers.cookie) authStatusCache.delete(authCacheKey(req.headers.cookie));
 
-  for (const name of Object.keys(req.cookies ?? {})) {
-    if (name === "lang") continue; // A display preference, not part of the session.
-    res.clearCookie(name, { path: "/" });
-    if (config.project.cookieDomain) res.clearCookie(name, { path: "/", domain: config.project.cookieDomain });
-  }
+  const sessionCookie = config.project.sessionCookie ?? "urlate";
+  res.clearCookie(sessionCookie, { path: "/" });
+  if (config.project.cookieDomain) res.clearCookie(sessionCookie, { path: "/", domain: config.project.cookieDomain });
 
   res.redirect(`${config.project.api}/auth/logout?redirect=true`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import cookieParser from "cookie-parser";
-import express from "express";
+import express, { NextFunction, Request, Response } from "express";
 import i18n from "./i18n";
 import multer from "multer";
 import path from "path";
@@ -73,7 +73,56 @@ app.get("/join", (req, res) => {
   res.render("join", { api: config.project.api, ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version, url: config.project.url });
 });
 
-app.get("/game", async (req, res) => {
+/**
+ * Gate the pages that only make sense for a signed-in player.
+ *
+ * The status -> destination mapping is the one each page used to run in the
+ * browser after loading. Doing it here means an unauthenticated request never
+ * receives the page at all, so the check can no longer be skipped by disabling
+ * JavaScript or dropping the redirect.
+ */
+const requireAuth = (extraRedirects: Record<string, string> = {}) => {
+  const redirects: Record<string, string> = {
+    "Not registered": `${config.project.url}/join`,
+    "Not logined": config.project.url,
+    Shutdowned: `${config.project.api}/auth/logout?redirect=true&shutdowned=true`,
+    ...extraRedirects,
+  };
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    // The response depends on the session, so it must never be cached.
+    res.setHeader("Cache-Control", "no-store");
+    if (!req.headers.cookie) return res.redirect(redirects["Not logined"]);
+    try {
+      const response = await fetch(`${config.project.api}/auth/status`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: req.headers.cookie,
+        },
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+      if (!response.ok) return res.redirect(config.project.url);
+      const data: any = await response.json();
+      const redirect = redirects[data.status];
+      if (redirect) return res.redirect(redirect);
+      next();
+    } catch (err) {
+      // Fail closed: an unreachable backend must not open the gate.
+      logger.warn("Failed to check auth status", { path: req.path, error: err });
+      res.redirect(config.project.url);
+    }
+  };
+};
+
+// The editor is gated on more than a login: authorization and identity verification.
+const editorRedirects = {
+  "Not authorized": `${config.project.url}/authorize`,
+  "Not authenticated": `${config.project.url}/authentication`,
+  "Not authenticated(adult)": `${config.project.url}/authentication?adult=1`,
+};
+
+app.get("/game", requireAuth(), async (req, res) => {
   res.render("game", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -83,7 +132,7 @@ app.get("/game", async (req, res) => {
   });
 });
 
-app.get("/editor", async (req, res) => {
+app.get("/editor", requireAuth(editorRedirects), async (req, res) => {
   res.render("editor", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -93,7 +142,7 @@ app.get("/editor", async (req, res) => {
   });
 });
 
-app.get("/test", async (req, res) => {
+app.get("/test", requireAuth(), async (req, res) => {
   res.render("test", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -103,7 +152,7 @@ app.get("/test", async (req, res) => {
   });
 });
 
-app.get("/play", async (req, res) => {
+app.get("/play", requireAuth(), async (req, res) => {
   res.render("play", {
     cdn: config.project.cdn,
     url: config.project.url,
@@ -113,7 +162,7 @@ app.get("/play", async (req, res) => {
   });
 });
 
-app.get("/tutorial", async (req, res) => {
+app.get("/tutorial", requireAuth(), async (req, res) => {
   res.render("tutorial", {
     cdn: config.project.cdn,
     url: config.project.url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,13 +154,9 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
   res.setHeader("Cache-Control", "no-store");
   if (!req.headers.cookie) return res.redirect(authRedirects["Not logined"]);
 
+  // Only passing statuses are cached, so a hit is a pass.
   const key = authCacheKey(req.headers.cookie);
-  const cached = readCachedStatus(key);
-  if (cached !== null) {
-    const redirect = authRedirects[cached];
-    if (redirect) return res.redirect(redirect);
-    return next();
-  }
+  if (readCachedStatus(key) !== null) return next();
 
   try {
     const response = await fetch(`${config.project.api}/auth/status`, {
@@ -173,10 +169,10 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
     });
     if (!response.ok) return res.redirect(config.project.url);
     const data: any = await response.json();
-    const status = String(data.status);
+    const status = data.status;
+    if (typeof status !== "string") return res.redirect(config.project.url);
     writeCachedStatus(key, status);
-    const redirect = authRedirects[status];
-    if (redirect) return res.redirect(redirect);
+    if (gatedStatuses.has(status)) return res.redirect(authRedirects[status]);
     next();
   } catch (err) {
     // Fail closed: an unreachable backend must not open the gate.
@@ -185,22 +181,47 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
+const ownOrigin = (() => {
+  try {
+    return new URL(config.project.url).origin;
+  } catch {
+    return null;
+  }
+})();
+
+// A top-level GET carries no Origin, so fall back to the Referer -- the same pair
+// the backend reads on its own logout route.
+const startedHere = (req: Request) => {
+  const header = req.get("origin") ?? req.get("referer");
+  if (!header || ownOrigin === null) return false;
+  try {
+    return new URL(header).origin === ownOrigin;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Sign the visitor out. The backend still performs the real logout; this route
  * drops the session cookie and the cached status on the way there, so a destroyed
  * session stops passing the gate at once rather than when its entry expires.
  *
+ * Those two are done only for a sign-out that started on our own pages, or a link
+ * from anywhere else could sign a visitor out. The redirect stays unconditional,
+ * so a request that fails the check behaves exactly as it did before this route
+ * existed: the backend applies the same check and refuses.
+ *
  * `sessionCookie` and `cookieDomain` must match what the backend sets; if they do
  * not the cookie survives and only the eviction takes effect.
  */
 app.get("/logout", logoutLimiter, (req, res) => {
-  if (req.headers.cookie) authStatusCache.delete(authCacheKey(req.headers.cookie));
+  if (startedHere(req)) {
+    if (req.headers.cookie) authStatusCache.delete(authCacheKey(req.headers.cookie));
+    const sessionCookie = config.project.sessionCookie ?? "urlate";
+    res.clearCookie(sessionCookie, { path: "/" });
+    if (config.project.cookieDomain) res.clearCookie(sessionCookie, { path: "/", domain: config.project.cookieDomain });
+  }
 
-  const sessionCookie = config.project.sessionCookie ?? "urlate";
-  res.clearCookie(sessionCookie, { path: "/" });
-  if (config.project.cookieDomain) res.clearCookie(sessionCookie, { path: "/", domain: config.project.cookieDomain });
-
-  // The backend checks the origin here, reading it from the Referer, which survives this hop.
   res.redirect(`${config.project.api}/auth/logout?redirect=true`);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,32 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
+/**
+ * Sign the visitor out.
+ *
+ * The backend owns the session and still performs the real logout; this route
+ * exists so the session cookie and the cached status are dropped on the way
+ * there. Without it a visitor keeps passing the gate on a cached status until
+ * it expires, and the pages they get are useless because the session is gone.
+ *
+ * Clearing a cookie only works for names this host can write, so a cookie the
+ * backend scoped to its own host stays; `cookieDomain` covers the common case
+ * of a session shared across subdomains. The cache eviction is what closes the
+ * window either way: with the entry gone the next gated request has to ask the
+ * backend again, whether or not the cookie survived.
+ */
+app.get("/logout", (req, res) => {
+  if (req.headers.cookie) authStatusCache.delete(authCacheKey(req.headers.cookie));
+
+  for (const name of Object.keys(req.cookies ?? {})) {
+    if (name === "lang") continue; // A display preference, not part of the session.
+    res.clearCookie(name, { path: "/" });
+    if (config.project.cookieDomain) res.clearCookie(name, { path: "/", domain: config.project.cookieDomain });
+  }
+
+  res.redirect(`${config.project.api}/auth/logout?redirect=true`);
+});
+
 app.get("/game", gateLimiter, requireAuth, async (req, res) => {
   res.render("game", {
     cdn: config.project.cdn,

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,10 +135,17 @@ const writeCachedStatus = (key: string, status: string) => {
  * A cache miss costs a lookup against the backend, and a caller can force a miss
  * on every request just by varying the cookie it sends. One limiter is shared by
  * the gated pages, so the budget covers their combined load.
+ *
+ * A request already holding a cached pass never reaches the backend, so it does
+ * not spend from the budget. That keeps shared addresses -- a school or a home
+ * behind one NAT -- from starving each other, while a caller cycling cookies
+ * misses every time and stays limited. Since ordinary play barely draws on it,
+ * the budget can be small.
  */
 const gateLimiter = rateLimit({
   windowMs: 60 * 1000,
-  limit: 60,
+  limit: 30,
+  skip: (req) => !!req.headers.cookie && readCachedStatus(authCacheKey(req.headers.cookie)) !== null,
   standardHeaders: true,
   legacyHeaders: false,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,8 @@ const API_TIMEOUT_MS = 5000;
 const app = express();
 app.locals.pretty = true;
 
-// The rate limiter below keys on the client address, which arrives in
-// X-Forwarded-For from the CDN and reverse proxy in front. Trusting more hops
-// than actually exist would let a caller spoof it, so the count is configurable.
+// Rate limiting keys on the client address, which arrives via X-Forwarded-For.
+// Trusting more hops than actually exist would let a caller spoof it.
 app.set("trust proxy", config.project.trustProxy ?? 1);
 
 app.set("view engine", "ejs");
@@ -85,22 +84,15 @@ const authRedirects: Record<string, string> = {
   "Not logined": config.project.url,
 };
 
-// Statuses that send the visitor elsewhere instead of rendering the page.
 const gatedStatuses = new Set(Object.keys(authRedirects));
 
 /**
  * Short-lived cache of the backend's auth status, keyed by the caller's cookies.
+ * Gated pages are `no-store`, so without it every navigation costs a round trip.
  *
- * Gated pages carry `no-store`, so the CDN in front cannot absorb them and every
- * navigation reaches this process. Without this cache each one would also cost a
- * round trip to the backend.
- *
- * Only statuses that let the visitor through are stored. Caching a gated status
- * would trap a user who just resolved it: finishing signup sends the browser to
- * /game, and a stale "Not registered" would bounce it back to /join, which sends
- * it to /game again. Gated statuses are rare and short-lived, so they are always
- * re-checked; the cache exists for the steady state of an ordinary player moving
- * between pages.
+ * Only passing statuses are stored. A cached gated status would trap the user who
+ * just resolved it: finishing signup sends the browser to /game, a stale
+ * "Not registered" bounces it to /join, and /join sends it back to /game.
  */
 const AUTH_CACHE_TTL_MS = 30 * 1000;
 const AUTH_CACHE_MAX_ENTRIES = 5000;
@@ -130,17 +122,11 @@ const writeCachedStatus = (key: string, status: string) => {
 };
 
 /**
- * Bound how much backend traffic one address can generate through the gate.
+ * Bound the backend traffic one address can drive through the gate: a cache miss
+ * costs a lookup, and a caller can force one every time by varying the cookie.
  *
- * A cache miss costs a lookup against the backend, and a caller can force a miss
- * on every request just by varying the cookie it sends. One limiter is shared by
- * the gated pages, so the budget covers their combined load.
- *
- * A request already holding a cached pass never reaches the backend, so it does
- * not spend from the budget. That keeps shared addresses -- a school or a home
- * behind one NAT -- from starving each other, while a caller cycling cookies
- * misses every time and stays limited. Since ordinary play barely draws on it,
- * the budget can be small.
+ * A cached pass never reaches the backend, so it does not spend from the budget.
+ * That also keeps users behind one shared address from starving each other.
  */
 const gateLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -150,13 +136,7 @@ const gateLimiter = rateLimit({
   legacyHeaders: false,
 });
 
-/**
- * Logout gets its own budget rather than sharing the one above.
- *
- * It costs nothing on the backend, so it does not belong to the gate's budget,
- * and keeping it separate means a burst of page loads can never leave a visitor
- * unable to sign out. Signing out is idempotent and rare, so this can be small.
- */
+// Its own budget, so a burst of page loads can never leave a visitor unable to sign out.
 const logoutLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 20,
@@ -165,15 +145,12 @@ const logoutLimiter = rateLimit({
 });
 
 /**
- * Gate the pages that only make sense for a signed-in player.
- *
- * The status -> destination mapping is the one each page used to run in the
- * browser after loading. Doing it here means an unauthenticated request never
- * receives the page at all, so the check can no longer be skipped by disabling
- * JavaScript or dropping the redirect.
+ * Gate the pages that only make sense for a signed-in player. The status ->
+ * destination mapping is the one the pages used to run in the browser; doing it
+ * here means the check cannot be skipped by disabling JavaScript.
  */
 const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
-  // The response depends on the session, so neither the CDN nor the browser may cache it.
+  // Depends on the session, so neither the CDN nor the browser may cache it.
   res.setHeader("Cache-Control", "no-store");
   if (!req.headers.cookie) return res.redirect(authRedirects["Not logined"]);
 
@@ -209,21 +186,12 @@ const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
 };
 
 /**
- * Sign the visitor out.
+ * Sign the visitor out. The backend still performs the real logout; this route
+ * drops the session cookie and the cached status on the way there, so a destroyed
+ * session stops passing the gate at once rather than when its entry expires.
  *
- * The backend owns the session and still performs the real logout; this route
- * exists so the session cookie and the cached status are dropped on the way
- * there. Without it a visitor keeps passing the gate on a cached status until
- * it expires, and the pages they get are useless because the session is gone.
- *
- * `sessionCookie` and `cookieDomain` name the backend's session cookie, so they
- * have to match what it sets. If they don't, the browser keeps the cookie and
- * only the cache eviction takes effect -- which is what closes the window in
- * either case, since the next gated request then has to ask the backend again.
- *
- * The redirect at the end keeps the backend's own logout in the flow. It is a
- * GET route that checks the request origin, and it reads that origin from the
- * Referer, which survives this hop.
+ * `sessionCookie` and `cookieDomain` must match what the backend sets; if they do
+ * not the cookie survives and only the eviction takes effect.
  */
 app.get("/logout", logoutLimiter, (req, res) => {
   if (req.headers.cookie) authStatusCache.delete(authCacheKey(req.headers.cookie));
@@ -232,6 +200,7 @@ app.get("/logout", logoutLimiter, (req, res) => {
   res.clearCookie(sessionCookie, { path: "/" });
   if (config.project.cookieDomain) res.clearCookie(sessionCookie, { path: "/", domain: config.project.cookieDomain });
 
+  // The backend checks the origin here, reading it from the Referer, which survives this hop.
   res.redirect(`${config.project.api}/auth/logout?redirect=true`);
 });
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -63,7 +63,6 @@
       const api = "<%= api %>";
       const loginFailed = "<%= __('login_failed') %>";
       const loginError = "<%= __('login_error') %>";
-      const shutdownAlert = "<%= __('shutdowned_alert') %>";
       const lang = "<%= __('lang') %>";
     </script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -19,7 +19,7 @@
     <span id="nameExist"><%= __('nameExist') %></span>
     <span id="name"><%= __('nameText') %></span>
     <input type="submit" class="button" onclick="check()" value="<%= __('done') %>" />
-    <h5><a href="<%= api %>/auth/logout?redirect=true" style="color: rgb(0, 135, 197); font-weight: 400"><%= __('mainPage') %></a></h5>
+    <h5><a href="/logout" style="color: rgb(0, 135, 197); font-weight: 400"><%= __('mainPage') %></a></h5>
     <script>
       const projectUrl = "<%= url %>";
       const api = "<%= api %>";


### PR DESCRIPTION
#316 을 대체합니다. 지적된 문제는 유효하나 구현이 기존 동작을 보존하지 않아 다시 작성했습니다.

## 문제

`/game`, `/editor`, `/play`, `/test`, `/tutorial` 이 서버측 검사 없이 렌더링되고 있었습니다. 인증 판정 전체가 페이지 로드 후 클라이언트 JS에 맡겨져 있어, JS를 끄면 그대로 통과합니다.

다만 심각도는 높지 않습니다. 이 페이지들은 공개 설정값(`cdn`, `api`, `url`, 버전)만 담은 EJS 껍데기이고 실제 권한은 백엔드 API가 판정하므로, 익명으로 받아가도 노출되는 정보가 없습니다. 서버 게이트의 가치는 JS 없이도 올바른 곳으로 보내는 것과 방어 계층입니다.

## 서버측 게이트

`requireAuth` 미들웨어가 세션 쿠키를 백엔드 `/auth/status` 로 전달하고, 클라이언트가 하던 상태별 리다이렉트를 그대로 수행합니다. #316 은 `/user` 성공 여부만 보고 전부 `/` 로 보내는데, 그러면 가입이 필요한 사용자가 `/join` 대신 메인으로 튕기고 에디터 권한 검사도 사라집니다.

세션에 따라 응답이 달라지므로 `Cache-Control: no-store` 를 붙였습니다. 앞단에 CDN이 있는 구성에서는 이게 필수입니다 — 없으면 인증된 사용자에게 나간 `200` 이나 특정 사용자의 `302` 가 캐시되어 게이트가 무력화됩니다. 기존에는 이 라우트들이 캐시 헤더를 아예 보내지 않았습니다.

서버가 같은 판정을 하므로 5개 페이지에서 클라이언트의 `/auth/status` 왕복을 제거하고 설정·닉네임을 읽는 `/user` 호출만 남겼습니다. 페이지당 요청 1회와 로드 직후 깜빡임이 사라집니다.

## 미사용 상태값 제거

백엔드가 더이상 내려주지 않는 `Not authorized`, `Not authenticated`, `Not authenticated(adult)`, `Shutdowned` 분기를 제거했습니다. 에디터 전용 매핑이 사라져 `requireAuth` 도 팩토리에서 일반 미들웨어로 되돌렸습니다. 어디에서도 참조하지 않던 `shutdownAlert` 선언과 `shutdowned_alert` 로케일 문구도 함께 정리했습니다.

남은 게이트 상태는 `Not registered` → `/join`, `Not logined` → `/` 둘뿐입니다.

## auth 상태 30초 캐시

게이트된 페이지는 엣지 캐시가 불가능해 모든 이동이 origin까지 옵니다. 여기 매번 백엔드 왕복이 얹히던 것을 세션 쿠키 해시 기준 30초 캐시로 줄였습니다.

통과 상태만 캐시합니다. 차단 상태를 캐시하면 그것을 막 해소한 사용자가 갇힙니다 — 가입을 마치면 `/game` 으로 이동하는데 낡은 `Not registered` 가 `/join` 으로 되돌리고, `/join` 은 다시 `/game` 으로 보내 TTL 동안 리다이렉트 루프가 됩니다. 쿠키는 sha256으로 해싱해 세션 토큰을 메모리에 들고 있지 않게 했고, 항목 수 상한을 두었습니다. 백엔드 실패는 캐시하지 않아 복구가 즉시 반영됩니다.

## rate limit

게이트가 붙으면서 이 라우트들이 인가를 수행하게 되었고, CodeQL이 요청량 제한 부재를 지적했습니다. 근거가 있는 지적입니다 — 캐시 미스는 백엔드 조회 1회를 유발하고 쿠키 값을 매번 바꾸면 항상 미스가 나므로, 프론트엔드가 백엔드로 가는 증폭 경로가 됩니다.

게이트된 5개 라우트가 주소당 예산을 공유하고, `/logout` 은 더 작은 자기 예산을 씁니다. 예산을 나눠야 페이지 로드가 몰렸을 때 로그아웃이 막히지 않습니다. **이미 캐시된 통과는 예산을 쓰지 않습니다** — 백엔드에 닿지 않으므로 예산에 넣을 이유가 없고, 덕분에 공유 주소(NAT) 뒤의 사용자들이 서로를 굶기지 않으면서 쿠키를 매번 바꾸는 호출자는 항상 미스라 그대로 제한됩니다.

클라이언트 주소가 CDN·리버스 프록시의 `X-Forwarded-For` 로 오므로 `trust proxy` 를 설정했습니다. 신뢰 홉 수는 `config.trustProxy` 로 조정 가능하고 기본값은 1입니다.

## 로그아웃

로그아웃이 백엔드로 곧장 나가고 있어서, 세션이 파기된 뒤에도 캐시된 통과 상태가 만료될 때까지 게이트를 통과했습니다. 프론트엔드에 `/logout` 을 두고 경유시킵니다.

캐시 항목을 제거하고, 세션 쿠키 `urlate` 를 현재 호스트와 `config.cookieDomain` 기준으로 지운 뒤, 백엔드 로그아웃으로 리다이렉트합니다. 쿠키 삭제가 도메인 설정 문제로 실패해도 캐시 제거가 보장을 합니다 — 다음 요청이 반드시 백엔드에 다시 묻게 되기 때문입니다.

관련해서, `/user` 가 실패하면 페이지들이 alert 를 띄우고 멈추는 대신 `/logout` 으로 갑니다. 세션을 더 못 쓴다는 신호이므로 정리하고 나가는 게 맞습니다. 네트워크 오류를 다루는 `catch` 는 그대로 두었습니다. 일시적 장애로 로그아웃시킬 이유는 없습니다.

## 검증

목 백엔드로 게이트·캐시·리미터·로그아웃 동작을 확인했습니다. 쿠키 없음, 상태별 리다이렉트, 캐시 히트 시 백엔드 호출 횟수, 세션 간 격리, 가입 직후 시나리오, 만료, 상한, 키 해싱, 백엔드 500 시 fail closed, 예산 소진과 복구, NAT 뒤 다수 세션, 쿠키를 바꾸는 폭주 차단까지 포함합니다.

경계 동작은 `URLATE-v3l-backend` 를 대조해 확인했습니다.

- 세션 쿠키는 `urlate`, 스코프는 백엔드 `session.domain` 과 path `/` 라 프론트엔드가 정확히 그것만 지웁니다.
- 백엔드 `GET /auth/logout` 은 출처를 검사하는데 `Origin` 이 아니라 **Referer** 로 판정합니다. 최상위 GET 내비게이션에는 `Origin` 이 붙지 않아 변경 전에도 Referer 에 의존하고 있었습니다. 프론트엔드를 경유하며 리다이렉트가 한 홉 늘어나므로, Referer 가 유지되어 검사를 통과하는지 실제 브라우저로 확인했습니다.
- 백엔드의 `/auth/status` 캐시는 userid 로 키를 잡고 "가입 여부" 만 담습니다. 로그인 여부는 세션에서 직접 보므로 세션이 파기되면 캐시와 무관하게 즉시 `Not logined` 입니다.

`tsc`, eslint, prettier 통과.

## 남는 한계

- 백엔드가 세션을 파기했는데 사용자가 `/logout` 을 거치지 않은 경우(다른 기기에서의 강제 로그아웃 등) 최대 30초간 페이지가 뜹니다. 이때는 `/user` 가 실패하면서 로그아웃으로 정리됩니다. 창을 0으로 만들려면 캐시를 없애거나 백엔드가 무효화를 통지해야 하는데, 캐시가 실제로 얼마를 버는지 재본 뒤에 정하는 게 맞다고 봅니다.
- `skip` 때문에 로그인한 사용자는 게이트 리미터에 사실상 걸리지 않습니다. 캐시 히트로 EJS 렌더를 반복 유발할 수 있으나 백엔드 증폭보다 훨씬 가볍고 앞단 CDN이 흡수하는 층이라 그대로 두었습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAof4jmHP1j1VZtgN7cMAd