### PR TITLE
fix(game): 곡 선택 화면의 정렬·난이도·곡 복원 수정

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -588,12 +588,15 @@ const sortSelected = (n, isInitializing) => {
   document.getElementsByClassName("sortText")[n].classList.add("selected");
   const sortArray = [sortAsName, sortAsProducer, sortAsDifficulty, sortAsBPM];
   currentSong?.stop();
-  const prevName = tracks[songSelection].fileName;
+  const prevName = tracks[songSelection]?.fileName;
+  const prevRecords = new Map(tracks.map((track, i) => [track.fileName, trackRecords[i]]));
   tracks.sort(sortAsName);
   tracks.sort(sortArray[n]);
+  trackRecords = tracks.map((track) => prevRecords.get(track.fileName));
   tracksUpdate();
-  const index = tracks.findIndex((obj) => obj.fileName == prevName);
-  if (!isInitializing) songSelected(index, true, seek);
+  const index = prevName ? tracks.findIndex((obj) => obj.fileName == prevName) : -1;
+  if (index != -1) songSelection = index;
+  if (!isInitializing && index != -1) songSelected(index, true, seek);
 };
 
 const songSelected = (n, refreshed, seek) => {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -792,10 +792,6 @@ const numberWithCommas = (x) => {
 
 const gameLoaded = () => {
   if (iniMode == 1) {
-    const restoreIndex = localStorage.songName ? tracks.findIndex((e) => e.fileName == localStorage.songName) : -1;
-    if (restoreIndex != -1 && tracks[restoreIndex].type != 3) {
-      songSelected(restoreIndex, true);
-    }
     menuSelected(0);
   } else if (display == 0 && songSelection == -1) {
     themeSong.play();
@@ -1103,9 +1099,15 @@ const menuSelected = (n) => {
     //play
     display = 1;
     if (songSelection == -1) {
-      const playable = tracks.map((t, i) => (t.type != 3 ? i : -1)).filter((i) => i != -1);
-      if (playable.length > 0) {
-        songSelected(playable[Math.floor(Math.random() * playable.length)]);
+      // Restore the last played song; pick a random one only when there is nothing to restore.
+      const savedIndex = localStorage.songName ? tracks.findIndex((e) => e.fileName == localStorage.songName) : -1;
+      if (savedIndex != -1 && tracks[savedIndex].type != 3) {
+        songSelected(savedIndex);
+      } else {
+        const playable = tracks.map((t, i) => (t.type != 3 ? i : -1)).filter((i) => i != -1);
+        if (playable.length > 0) {
+          songSelected(playable[Math.floor(Math.random() * playable.length)]);
+        }
       }
     }
     document.getElementById("selectContainer").style.display = "flex";

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -465,7 +465,8 @@ document.addEventListener("DOMContentLoaded", () => {
             if (data.result == "success") {
               tracks = data.tracks;
               tracks.sort(sortAsName);
-              tracksUpdate();
+              // sortSelected already runs tracksUpdate, so skip it when a saved sort was restored.
+              if (!restoreSortSettings()) tracksUpdate();
               Howler.volume(settings.sound.volume.master * settings.sound.volume.music);
               intro1video.volume = settings.sound.volume.master * settings.sound.volume.music;
               intro2video.volume = settings.sound.volume.master * settings.sound.volume.music;
@@ -490,6 +491,21 @@ document.addEventListener("DOMContentLoaded", () => {
       location.reload();
     });
 });
+
+const restoreSortSettings = () => {
+  const savedDifficulty = Number(localStorage.difficultySelection ?? 0);
+  if (savedDifficulty > 0 && savedDifficulty <= 2) {
+    difficultySelection = savedDifficulty;
+    document.getElementsByClassName("difficultySelected")[0].classList.remove("difficultySelected");
+    document.getElementsByClassName("difficulty")[savedDifficulty].classList.add("difficultySelected");
+  }
+  const savedSort = Number(localStorage.sort ?? 0);
+  if (savedSort > 0 && savedSort <= 3) {
+    sortSelected(savedSort, true);
+    return true;
+  }
+  return false;
+};
 
 const tracksUpdate = () => {
   songs.forEach((s) => s.unload());
@@ -1568,6 +1584,7 @@ const updateDetails = (n) => {
 
 const difficultySelected = (n, isInitializing) => {
   difficultySelection = n;
+  localStorage.difficultySelection = n;
   document.getElementsByClassName("difficultySelected")[0].classList.remove("difficultySelected");
   document.getElementsByClassName("difficulty")[n].classList.add("difficultySelected");
   updateDetails(songSelection);

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -630,7 +630,6 @@ const songSelected = (n, refreshed, seek) => {
       setTimeout(() => {
         localStorage.rate = rate;
         localStorage.disableText = disableText;
-        localStorage.songNum = songSelection;
         localStorage.difficultySelection = difficultySelection;
         localStorage.difficulty = JSON.parse(tracks[songSelection].difficulty)[difficultySelection];
         localStorage.songName = tracks[songSelection].fileName;
@@ -794,11 +793,9 @@ const numberWithCommas = (x) => {
 
 const gameLoaded = () => {
   if (iniMode == 1) {
-    if (localStorage.songNum) {
-      songSelection = Number(localStorage.songNum);
-      sortSelected(Number(localStorage.sort ? localStorage.sort : 0), true);
-      songSelected(songSelection, true);
-      difficultySelected(Number(localStorage.difficultySelection ? localStorage.difficultySelection : 0), true);
+    const restoreIndex = localStorage.songName ? tracks.findIndex((e) => e.fileName == localStorage.songName) : -1;
+    if (restoreIndex != -1 && tracks[restoreIndex].type != 3) {
+      songSelected(restoreIndex, true);
     }
     menuSelected(0);
   } else if (display == 0 && songSelection == -1) {
@@ -807,8 +804,6 @@ const gameLoaded = () => {
   profileSong.play();
   document.getElementById("menuContainer").style.display = "flex";
   document.getElementById("loadingContainer").classList.add("fadeOutAnim");
-  localStorage.removeItem("songName");
-  localStorage.removeItem("difficulty");
   setTimeout(() => {
     if (tutorial >= 3) {
       document.getElementById("tutorialInformation").style.display = "flex";

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -551,7 +551,6 @@ const tracksUpdate = () => {
 
   const defaultRecord = (type) => ({ rank: type == 1 ? "rankL" : "rankQ", record: 0, medal: 0, maxcombo: 0 });
 
-  // 곡마다 따로 묻지 않고 내 기록 전체를 한 번에 받아옵니다.
   fetch(`${api}/trackRecords/${username}`, { method: "GET", credentials: "include" })
     .then((res) => res.json())
     .then((data) => {
@@ -1218,7 +1217,7 @@ const profileUpdate = async (uid, isMe) => {
       document.getElementsByClassName("profileStatValue")[5].textContent = "-";
       document.getElementById("profileRecentPlay").innerHTML = `<span class="nothingHere">${nothingHere}</span>`;
     } else {
-      // 기록 id마다 따로 묻지 않고 최근 플레이 목록을 한 번에 받아옵니다.
+      // Fetch the whole recent play list at once instead of asking per record id.
       const recentRes = await fetch(`${api}/recentPlays/${uid}`, { method: "GET", credentials: "include" }).then((res) => res.json());
       const recentResults = recentRes.result == "success" ? recentRes.results : [];
       let recentHTML = "";
@@ -1735,7 +1734,7 @@ const visualSyncSetting = () => {
   document.getElementById("visualSyncContainer").classList.add("fadeInAnim");
   document.getElementById("visualSyncValueText").textContent = visualSyncOffset + "ms";
 
-  // offsetSong 재생 (offset 설정과 동일)
+  // Play offsetSong, same as the offset setting screen.
   if (songSelection != -1) {
     const selSong = getSong(songSelection);
     if (selSong) selSong.fade(1, 0, 500);
@@ -1754,14 +1753,14 @@ const visualSyncSetting = () => {
   const drawFrame = () => {
     if (display !== 13) return;
 
-    // offsetUpdate와 동일한 방식으로 오디오 기준 seek 계산
+    // Compute the audio based seek the same way offsetUpdate does.
     const howlerCtx = Howler.ctx;
     const audioLatency = (howlerCtx?.outputLatency ?? 0) + (howlerCtx?.baseLatency ?? 0);
     const seek = Math.max(0, offsetSong.seek() - audioLatency);
 
-    const cycle = beat * 2; // 2비트마다 노트 한 개
+    const cycle = beat * 2; // one note every two beats
 
-    // visualSyncOffset만큼 앞당긴 비주얼 seek로 노트 progress 계산
+    // Compute the note progress from a visual seek pulled ahead by visualSyncOffset.
     const visualSeek = seek + visualSyncOffset / 1000;
     const visualCyclePos = ((visualSeek % cycle) + cycle) % cycle;
     const visualCycleOffset = visualCyclePos - cycle; // -cycle ~ 0


### PR DESCRIPTION
플레이 후 곡 선택 화면으로 돌아왔을 때 이전 정렬 옵션과 곡이 복원되지 않던 문제를 고칩니다.

## 무엇이 깨져 있었나

- **곡 복원이 인덱스 기반**: `localStorage.songNum`은 저장 당시 정렬 순서의 인덱스인데, 다시 들어오면 목록이 이름순으로 정렬된 뒤라 정렬 옵션이 이름순이 아니었거나 곡이 추가됐으면 다른 곡이 선택됐다.
- **정렬을 난이도 복원보다 먼저 수행**: `sortAsDifficulty`는 전역 `difficultySelection`을 보는데 복원 전이라 항상 Easy 기준으로 정렬됐다. 난이도별 정렬을 저장해도 다른 순서가 나왔다.
- **`trackRecords` 인덱스 어긋남**: `trackRecords`는 tracks 인덱스를 키로 쓰는데 정렬 후 `tracksUpdate`의 비동기 재조회가 끝날 때까지 이전 순서로 남아 있었다. 그 사이 다른 곡의 기록/랭크/메달이 그려지고, 이전 순서의 숨김 곡(type 3) 인덱스에 걸리면 TypeError가 났다.
- **저장 시점이 플레이 시작 때뿐**: 곡을 고르지 않고 나가면 정렬·난이도 설정이 사라졌다.

## 변경

1. `fix(game)`: 정렬과 동시에 `trackRecords`를 fileName 기준으로 동기 재배치, `songSelection`도 새 인덱스로 갱신. 곡 미선택(`songSelection == -1`) 상태의 정렬도 안전하게 처리.
2. `feat(game)`: 난이도를 고를 때마다 저장하고, 곡 목록을 받는 즉시 `restoreSortSettings`로 정렬·난이도 복원. 난이도를 맞춘 뒤 정렬한다.
3. `fix(game)`: 곡 복원을 `songName` 기준으로 변경, `songNum` 제거. `gameLoaded`에서 `songName`/`difficulty`를 지우던 코드 삭제 (플레이 시작 시 항상 새로 쓰이므로 오래된 값이 쓰이지 않음).
4. `style(game)`: 한글 주석을 영어로 변경.

## 확인

- 각 커밋 시점에서 `eslint` 통과.
- 확인해볼 흐름: BPM 정렬 + HARD 선택 후 플레이 없이 재진입 → 정렬/난이도 유지. 곡 플레이 후 복귀 → 곡까지 복원.

🤖 Generated with [Claude Code](https://claude.com/claude-code)