### PR TITLE
fix: package.json에서 직접 버전을 읽도록 변경

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ exec("git branch --show-current", (err, stdout, stderr) => {
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const config = require(__dirname + "/../config/config.json");
 
+const version = require(__dirname + "/../package.json").version;
+
 let model;
 
 // node-fetch has no default timeout: a hung backend would pin the request handler.
@@ -61,7 +63,7 @@ app.get("/", (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
-    ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version,
+    ver: config.project.mode == "test" ? Date.now() : version,
     branch: branch,
   });
 });
@@ -77,7 +79,7 @@ app.get("/ko", function (req, res) {
 });
 
 app.get("/join", (req, res) => {
-  res.render("join", { api: config.project.api, ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version, url: config.project.url });
+  res.render("join", { api: config.project.api, ver: config.project.mode == "test" ? Date.now() : version, url: config.project.url });
 });
 
 const authRedirects: Record<string, string> = {
@@ -232,7 +234,7 @@ app.get("/game", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
-    ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version,
+    ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
 
@@ -242,7 +244,7 @@ app.get("/editor", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
-    ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version,
+    ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
 
@@ -252,7 +254,7 @@ app.get("/test", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
-    ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version,
+    ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
 
@@ -262,7 +264,7 @@ app.get("/play", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
-    ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version,
+    ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
 
@@ -272,7 +274,7 @@ app.get("/tutorial", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
-    ver: config.project.mode == "test" ? Date.now() : process.env.npm_package_version,
+    ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
 
@@ -550,7 +552,7 @@ process.on("uncaughtException", (error: Error) => {
     await loadModel();
 
     app.listen(config.project.port, () => {
-      logger.info(`URLATE-v3l-frontend is running on version ${config.project.mode == "test" ? Date.now() : process.env.npm_package_version}.`);
+      logger.info(`URLATE-v3l-frontend is running on version ${config.project.mode == "test" ? Date.now() : version}.`);
       logger.success(`HTTP Server running at port ${config.project.port}.`);
     });
   } catch (err) {


### PR DESCRIPTION
## 문제

deploy.yml로 프로덕션에 배포해도 `package.json`의 `version`이 반영되지 않습니다.

`src/index.ts`가 `process.env.npm_package_version`을 사용하는데, 이 변수는 npm/pnpm 스크립트가 node를 실행할 때만 설정됩니다. 배포 워크플로는 ssh로 `pm2 startOrReload ecosystem.config.js --update-env`를 직접 호출하므로 해당 변수가 없고, `--update-env`는 환경 변수를 병합만 할 뿐 삭제하지 않기 때문에 pm2는 과거에 `pnpm start`로 처음 기동했을 때 캡처한 값을 계속 유지합니다.

버전은 페이지의 `?v=` 캐시 버스터로도 쓰이므로, 값이 고정되면 정적 자산도 갱신되지 않습니다.

## 변경

시작 시 `package.json`에서 버전을 읽습니다. 렌더링 7곳과 기동 로그 1곳, 총 8개의 `process.env.npm_package_version` 사용처를 교체했습니다. 워크플로 변경은 필요하지 않습니다.

## 검증

- `pnpm run build` 통과 (tsc 오류 없음)
- `pnpm --filter=urlate deploy`를 실제로 실행해 산출물 루트에 `"version": "1.0.0-preview.5"`를 가진 `package.json`이 포함되는 것을 확인했습니다. 워크플로가 이어서 `cp -r dist ./deploy/`를 하므로 런타임에 `dist/index.js` 기준 `../package.json`으로 해석됩니다. 로컬 `pnpm start` 경로도 동일하게 동작합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)