### PR TITLE
feat(profile): 프로필 이미지를 BunnyCDN 저장소에 저장

### DIFF
--- a/config/config_example.json
+++ b/config/config_example.json
@@ -12,5 +12,11 @@
     "trustProxy": 2,
     "sessionCookie": "urlate",
     "cookieDomain": "example.com"
+  },
+  "bunny": {
+    "endpoint": "storage.bunnycdn.com",
+    "storageZone": "example-zone",
+    "accessKey": "Storage Zone Password",
+    "path": "profiles"
   }
 }

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -4,8 +4,8 @@ module.exports = {
       name: "URLATE-v3l-frontend",
       script: "dist/index.js",
 
-      // 재시작은 배포 워크플로의 pm2 startOrReload가 담당합니다.
-      // watch를 켜면 rsync 복사 도중 재시작이 걸릴 수 있습니다.
+      // Restarts are handled by pm2 startOrReload in the deploy workflow. With
+      // watch on, a restart could fire in the middle of the rsync copy.
       watch: false,
     },
   ],

--- a/public/js/join.js
+++ b/public/js/join.js
@@ -57,7 +57,7 @@ const check = () => {
         if (data.result == "success") {
           window.location.href = `${projectUrl}/game`;
         } else if (data.result == "failed") {
-          // 사용자가 이름만 바꾸면 되는 거부는 입력란 옆에 그대로 보여 줍니다.
+          // A rejection the user fixes by changing the name stays next to the field.
           const reason = { "Exist Name": joini18n.nameExist, "Reserved Name": joini18n.nameReserved }[data.error];
           if (reason) {
             const el = document.getElementById("nameExist");

--- a/public/js/play.js
+++ b/public/js/play.js
@@ -68,7 +68,7 @@ let great = 0;
 let good = 0;
 let bad = 0;
 let miss = 0;
-let bullet = 0; //miss와 bullet을 따로 처리
+let bullet = 0; // miss and bullet are tracked separately
 let mouseClicked = false;
 let menuAllowed = false;
 let mouseClickedMs = -1;
@@ -220,7 +220,7 @@ const initialize = (isFirstCalled) => {
         const findEnd = pattern.triggers.find((t) => t.value == 6);
         endBeat = findEnd ? findEnd.beat : null;
 
-        // 총알 생성 시점 속도를 한 번만 계산하여 캐싱 (bulletPos 내 첫 번째 탐색 제거)
+        // Cache the speed at spawn time so bulletPos does not have to look it up again
         bulletCreationSpeeds = calcBulletCreationSpeeds();
 
         document.getElementById("scoreDifficultyNum").textContent = localStorage.difficulty;
@@ -390,7 +390,6 @@ const cntRender = () => {
     ctx.lineWidth = 5;
     pointingCntElement = [{ v1: "", v2: "", i: "" }];
 
-    // 최적화된 트리거 처리 루프
     const renderTexts = [];
 
     while (currentTriggerIndex < pattern.triggers.length && pattern.triggers[currentTriggerIndex].beat <= beats) {
@@ -416,7 +415,7 @@ const cntRender = () => {
       currentTriggerIndex++;
     }
 
-    // 텍스트 트리거는 지속 시간이 있으므로 현재 비트 주변 탐색
+    // Text triggers have a duration, so search around the current beat
     let textEnd = upperBound(pattern.triggers, beats);
     let textStart = lowerBound(pattern.triggers, beats - 32);
     for (let i = textStart; i < textEnd; i++) {

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -68,7 +68,7 @@ let great = 0;
 let good = 0;
 let bad = 0;
 let miss = 0;
-let bullet = 0; //miss와 bullet을 따로 처리
+let bullet = 0; // miss and bullet are tracked separately
 let mouseClicked = false;
 let menuAllowed = false;
 let mouseClickedMs = -1;
@@ -371,7 +371,6 @@ const cntRender = () => {
     ctx.lineWidth = 5;
     pointingCntElement = [{ v1: "", v2: "", i: "" }];
 
-    // 최적화된 트리거 처리 루프
     const renderTexts = [];
 
     while (currentTriggerIndex < pattern.triggers.length && pattern.triggers[currentTriggerIndex].beat <= beats) {

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -67,7 +67,7 @@ let great = 0;
 let good = 0;
 let bad = 0;
 let miss = 0;
-let bullet = 0; //miss와 bullet을 따로 처리
+let bullet = 0; // miss and bullet are tracked separately
 let mouseClicked = false;
 let menuAllowed = false;
 let mouseClickedMs = -1;
@@ -345,7 +345,6 @@ const cntRender = () => {
     ctx.lineWidth = 5;
     pointingCntElement = [{ v1: "", v2: "", i: "" }];
 
-    // 최적화된 트리거 처리 루프
     const renderTexts = [];
 
     while (currentTriggerIndex < pattern.triggers.length && pattern.triggers[currentTriggerIndex].beat <= beats) {

--- a/public/modules/constants.js
+++ b/public/modules/constants.js
@@ -1,4 +1,4 @@
-/** 게임 내 이펙트 및 렌더링 관련 상수/설정값을 관리합니다. */
+/** Constants and settings for in-game effects and rendering. */
 export const Config = {
   MATH: {
     PI_5: Math.PI / 5,
@@ -71,7 +71,7 @@ export const Config = {
   },
 };
 
-/** 기본 판정 스킨 */
+/** Default judgement skin. */
 export const JudgeSkin = {
   perfect: {
     type: "gradient",
@@ -86,7 +86,7 @@ export const JudgeSkin = {
   miss: { type: "color", color: "#F96C5A" },
 };
 
-/** keyInput 오버레이 색상표 */
+/** Colour table for the keyInput overlay. */
 export const KeyInputColors = {
   Perfect: "#57BEEB",
   Great: "#73DFD2",

--- a/public/modules/factory.js
+++ b/public/modules/factory.js
@@ -1,19 +1,18 @@
 /**
  * factory.js
- * 게임 오브젝트 생성을 담당합니다.
+ * Creates game objects.
  */
 import { Config } from "./constants.js";
 
-// 오브젝트 풀 정의
 const EXPLOSION_POOL = [];
 const CLICK_POOL = [];
 const JUDGE_POOL = [];
 
-/** 캔버스에 그려질 게임 오브젝트(파티클, 노트 등)의 순수 데이터를 생성합니다. */
+/** Builds the plain data for the game objects (particles, notes, ...) drawn on the canvas. */
 export default class Factory {
   /**
-   * 폭발 효과를 위한 파티클 데이터 배열을 생성합니다.
-   * @returns {Array<object>} 생성된 파티클 객체들의 배열
+   * Build the particle data for an explosion effect.
+   * @returns {Array<object>} the particle objects
    */
   static createExplosions(x, y) {
     const particles = [];
@@ -24,7 +23,6 @@ export default class Factory {
       const angle = Math.random() * Math.PI * 2;
       const distance = conf.SPEED * (0.8 + Math.random() * 0.4);
 
-      // 풀에서 가져오거나 새로 생성
       const p = EXPLOSION_POOL.pop() || {};
       p.startX = x;
       p.startY = y;
@@ -41,7 +39,7 @@ export default class Factory {
   }
 
   /**
-   * 기본 클릭 이펙트를 위한 데이터를 생성합니다.
+   * Build the data for the default click effect.
    * @returns { object }
    */
   static createClickDefault(x, y) {
@@ -55,7 +53,7 @@ export default class Factory {
   }
 
   /**
-   * 노트 클릭 이펙트를 위한 데이터를 생성합니다.
+   * Build the data for the note click effect.
    * @returns { object }
    */
   static createClickNote(x, y, noteType) {
@@ -70,7 +68,7 @@ export default class Factory {
   }
 
   /**
-   * 판정 텍스트 이펙트 데이터를 생성합니다.
+   * Build the data for the judgement text effect.
    * @param {number} x
    * @param {number} y
    * @param {boolean} judgeSkin - settings.game.judgeSkin
@@ -89,7 +87,7 @@ export default class Factory {
   }
 
   /**
-   * 수명이 다한 객체를 풀로 반환합니다.
+   * Return an object that reached the end of its life to the pool.
    */
   static recycle(p) {
     if (!p) return;

--- a/public/modules/renderer.js
+++ b/public/modules/renderer.js
@@ -1,16 +1,16 @@
 /**
  * renderer.js
- * 게임의 캔버스 드로잉을 담당합니다.
+ * Canvas drawing for the game.
  */
 import { Config, JudgeSkin, KeyInputColors, DiffColors } from "./constants.js";
 import { getSin, getCos, hexadecimal, easeInQuad, easeOutQuad, easeOutQuart, numberWithCommas } from "./utils.js";
 
-/** 데이터를 받아 Canvas Context(ctx)에 실제 렌더링을 수행합니다. */
+/** Takes the data and renders it into the canvas context. */
 export default class Renderer {
   /**
    * @param {CanvasRenderingContext2D} ctx
    * @param {object} layout - { canvasW, canvasH, cursorZoom? }
-   * @param {object} skin - 스킨 데이터
+   * @param {object} skin - skin data
    */
   constructor(ctx, layout, skin) {
     this.ctx = ctx;
@@ -19,14 +19,14 @@ export default class Renderer {
     this.cursorZoom = layout.cursorZoom ?? 1;
     this.skin = skin;
 
-    // 렌더링 캐시
+    // Render caches
     this.cache = {
       bulletPath: null,
       lastCacheW: 0,
       gradient: new Map(), // skinPart -> Map(size -> gradient)
     };
 
-    // 애니메이션 상태
+    // Animation state
     this.animState = {
       score: { current: 0, start: 0, target: 0, startTime: 0 },
       combo: { value: 0, startTime: 0 },
@@ -35,7 +35,7 @@ export default class Renderer {
     this.cacheConfig();
   }
 
-  /** 내부 헬퍼: 좌표 변환 */
+  /** Helper: game coordinates -> canvas coordinates. */
   #getPos(x, y) {
     return {
       cx: ~~((this.canvasW / 200) * (x + 100)),
@@ -43,8 +43,8 @@ export default class Renderer {
     };
   }
 
-  /** 내부 헬퍼: 스킨 데이터(Gradient/Color)를 분석하여 ctx의 fillStyle 또는 strokeStyle을 설정합니다.
-   * 최적화: 그라데이션은 불투명하게 캐싱하고, 투명도는 ctx.globalAlpha로 조절합니다.
+  /** Helper: read the skin data (gradient or colour) and set fillStyle or strokeStyle.
+   * Gradients are cached fully opaque, and opacity is applied through ctx.globalAlpha.
    */
   #applyStyle(skinPart, x, y, size, opacity, isStroke = false) {
     const { ctx, canvasW } = this;
@@ -57,15 +57,15 @@ export default class Renderer {
       }
       style = sizeMap.get(size);
       if (!style) {
-        // 캐싱할 그라데이션은 (x, y)를 원점으로 하여 상대 좌표로 생성 (보통 x, y는 0)
+        // A cached gradient is built relative to (x, y) as the origin (usually 0, 0)
         style = ctx.createLinearGradient(x - size, y - size, x + size, y + size);
         for (let s = 0; s < skinPart.stops.length; s++) {
           style.addColorStop(skinPart.stops[s].percentage / 100, skinPart.stops[s].color);
         }
         sizeMap.set(size, style);
       }
-      // 그라데이션인 경우 opacity 처리는 호출 측에서 globalAlpha를 조절하도록 유도하거나,
-      // 여기서 직접 조절 (단, globalAlpha는 누적되므로 주의 필요)
+      // For a gradient the caller normally handles opacity through globalAlpha;
+      // setting it here works too, but globalAlpha accumulates.
     } else {
       style = hexadecimal(skinPart.color, opacity);
     }
@@ -76,14 +76,14 @@ export default class Renderer {
     } else ctx.fillStyle = style;
   }
 
-  /** 화면 크기가 변경되었을 때 호출
+  /** Called when the canvas size changed.
    * @param {object} layout - { canvasW, canvasH }
    */
   setSize(layout) {
     this.canvasW = layout.canvasW;
     this.canvasH = layout.canvasH;
 
-    // 화면 크기가 바뀌면 캐시 초기화
+    // A new canvas width invalidates the caches
     if (this.canvasW !== this.cache.lastCacheW) {
       this.cache.bulletPath = null;
       this.cache.gradient.clear();
@@ -92,7 +92,7 @@ export default class Renderer {
     this.cacheConfig();
   }
 
-  /** 컨피그 중 canvas size에 따라 달라지는 값 저장 */
+  /** Store the config values that depend on the canvas size. */
   cacheConfig() {
     const refX = this.canvasW / 1000;
     const refY = this.canvasH / 1000;
@@ -145,7 +145,7 @@ export default class Renderer {
       },
     };
 
-    // resize 시에만 바뀌는 고정 font 문자열 캐싱
+    // Font strings only change on resize, so build them once here
     const defaultSize = this.CONFIG.UI.DEFAULT_FONT_SIZE;
     const scorePanelSize = this.CONFIG.UI.SCORE_PANEL.FONT_SIZE;
     const judgeSize = ~~(this.canvasH / 25);
@@ -159,7 +159,7 @@ export default class Renderer {
     };
   }
 
-  /** 점수판 애니메이션 상태 초기화 */
+  /** Reset the score panel animation state. */
   initialize() {
     this.animState = {
       score: { current: 0, start: 0, target: 0, startTime: 0 },
@@ -168,7 +168,7 @@ export default class Renderer {
   }
 
   /**
-   * 테두리가 있는 텍스트를 그립니다. (스타일 설정 후 호출 필요)
+   * Draw outlined text. The styles must already be set.
    * @param {string} text
    * @param {number} x
    * @param {number} y
@@ -179,7 +179,7 @@ export default class Renderer {
   }
 
   /**
-   * 노트를 그립니다.
+   * Draw a note.
    * @param {object} note - { x, y, value, direction, debugIndex? }
    * @param {object} state - { globalAlpha, progress, tailProgress, endProgress, isGrabbed, isSelected? }
    */
@@ -188,16 +188,14 @@ export default class Renderer {
     const { x, y, value: type, direction } = note;
     const { globalAlpha, progress, tailProgress, endProgress, isGrabbed, isSelected } = state;
 
-    // 종료된 노트는 그리지 않음
+    // A finished note is not drawn
     if (type !== 2 && progress >= 130) return;
     if (type === 2 && endProgress >= 130) return;
 
-    // 공통 변수 계산
     const { cx, cy } = this.#getPos(x, y);
     const safeP = Math.max(progress, 0);
     let w = this.CONFIG.NOTE.WIDTH;
 
-    // 투명도 계산
     let opacityVal = 100;
     if (type !== 2 && safeP >= 100) {
       opacityVal = Math.max(130 - safeP, 0) * (10 / 3);
@@ -210,7 +208,6 @@ export default class Renderer {
     }
     const noteSkin = skin.note[type] || skin.note[0];
 
-    // 그리기 시작
     ctx.save();
     ctx.translate(cx, cy);
     ctx.globalAlpha = (opacityVal / 100) * globalAlpha;
@@ -235,19 +232,18 @@ export default class Renderer {
       ctx.fillStyle = "#ebd534";
       ctx.strokeStyle = "#ebd534";
     } else {
-      // 그라데이션 캐싱 활용을 위해 opacity는 100으로 넘기고 globalAlpha로 제어
+      // Pass opacity 100 so the cached gradient can be reused; globalAlpha does the fading
       this.#applyStyle(noteSkin, 0, 0, w, 100, false);
       this.#applyStyle(noteSkin.indicator, 0, 0, w, 100, true);
     }
 
-    // Type 0: Circle Note (일반)
+    // Type 0: Circle Note
     if (type === 0) {
-      // 타이밍 인디케이터
+      // Timing indicator
       ctx.beginPath();
       ctx.arc(0, 0, w, 1.5 * Math.PI, 1.5 * Math.PI + (safeP / 50) * Math.PI);
       ctx.stroke();
 
-      // 안쪽 채우기
       ctx.beginPath();
       ctx.arc(0, 0, (w / 100) * safeP, 0, 2 * Math.PI);
       ctx.fill();
@@ -256,7 +252,6 @@ export default class Renderer {
         ctx.stroke();
       }
 
-      // 틴트
       ctx.beginPath();
       ctx.globalAlpha *= (0.2 * Math.min(safeP * 2, 100)) / 100;
       ctx.fillStyle = ctx.strokeStyle;
@@ -264,27 +259,27 @@ export default class Renderer {
       ctx.fill();
     }
 
-    // Type 1: Arrow Note (플릭)
+    // Type 1: Arrow Note (flick)
     else if (type === 1) {
       w = w * 0.9;
 
-      // 애니메이션 단계 (0~20, 20~80, 80~100 구간별 진행도)
+      // Animation stages: progress within 0-20, 20-80 and 80-100
       const p1 = safeP <= 20 ? safeP * 5 : 100;
       const p2 = safeP > 20 ? Math.min((safeP - 20) * 1.66, 100) : 0;
       const p3 = safeP > 80 ? Math.min((safeP - 80) * 5, 100) : 0;
 
       const { PI_5, COS_36, SIN_36 } = Config.MATH;
 
-      // direction에 따라 캔버스 변형
+      // Flip the canvas by direction
       ctx.save();
       ctx.scale(direction, direction);
 
       ctx.beginPath();
 
-      // 날개 끝이자 원의 접점
+      // Wing tip, which is also where the arc meets
       const tipX = w * COS_36;
       const tipY = -w * SIN_36;
-      const tailY = -1.5 * w; // 뾰족한 부분
+      const tailY = -1.5 * w; // the sharp end
 
       // [Path 1] Tail(0, tailY) -> Right Tip(tipX, tipY)
       const dx1 = tipX;
@@ -293,7 +288,7 @@ export default class Renderer {
       ctx.moveTo(0, tailY);
       ctx.lineTo((dx1 / 100) * p1, tailY + (dy1 / 100) * p1);
 
-      // [Path 2] Arc (시계방향)
+      // [Path 2] Arc (clockwise)
       if (p2 > 0) {
         const arcLen = ((PI_5 * 7) / 100) * p2;
         ctx.arc(0, 0, w, -PI_5, -PI_5 + arcLen);
@@ -308,9 +303,8 @@ export default class Renderer {
       }
       ctx.stroke();
 
-      // 안쪽 채우기
       ctx.beginPath();
-      ctx.moveTo(0, -1.5 * (w / 100) * safeP); // 중심축
+      ctx.moveTo(0, -1.5 * (w / 100) * safeP); // centre axis
       ctx.arc(0, 0, (w / 100) * safeP, -PI_5, PI_5 * 6);
       ctx.lineTo(0, -1.5 * (w / 100) * safeP);
       ctx.fill();
@@ -319,7 +313,6 @@ export default class Renderer {
         ctx.stroke();
       }
 
-      // 틴트
       ctx.beginPath();
       ctx.globalAlpha *= (0.2 * Math.min(safeP * 2, 100)) / 100;
       ctx.fillStyle = ctx.strokeStyle;
@@ -331,11 +324,11 @@ export default class Renderer {
       ctx.restore();
     }
 
-    // Type 2: Hold Note (홀드)
+    // Type 2: Hold Note
     else if (type === 2) {
       ctx.beginPath();
       if (safeP <= 100) {
-        // 생성 중
+        // growing
         ctx.arc(0, 0, w, 1.5 * Math.PI, 1.5 * Math.PI + (safeP / 50) * Math.PI);
         ctx.lineTo(0, 0);
         ctx.fill();
@@ -343,12 +336,12 @@ export default class Renderer {
         ctx.arc(0, 0, w, 1.5 * Math.PI, 1.5 * Math.PI + (safeP / 50) * Math.PI);
         ctx.stroke();
       } else if (!isGrabbed) {
-        // 놓침
+        // missed
         ctx.arc(0, 0, w, 0, 2 * Math.PI);
         ctx.fill();
         ctx.stroke();
       } else if (tailProgress <= 100) {
-        // 잡는 중
+        // held
         ctx.arc(0, 0, w, 1.5 * Math.PI + (tailProgress / 50) * Math.PI, 1.5 * Math.PI);
         ctx.lineTo(0, 0);
         ctx.fill();
@@ -356,12 +349,11 @@ export default class Renderer {
         ctx.arc(0, 0, w, 0, 2 * Math.PI);
         ctx.stroke();
       } else {
-        // 완료
+        // finished
         ctx.arc(0, 0, w, 0, 2 * Math.PI);
         ctx.stroke();
       }
 
-      // 틴트
       ctx.beginPath();
       ctx.globalAlpha *= (0.2 * Math.min(safeP * 2, 100)) / 100;
       ctx.fillStyle = ctx.strokeStyle;
@@ -373,7 +365,7 @@ export default class Renderer {
   }
 
   /**
-   * 총알을 그립니다.
+   * Draw a bullet.
    * @param {object} bullet - { x, y, angle, location?, direction?, debugIndex? }
    * @param {object} state - { isSelected?, isHit? }
    */
@@ -385,7 +377,7 @@ export default class Renderer {
     const { cx, cy } = this.#getPos(x, y);
     const w = canvasW / 80;
 
-    // 총알 캐시 검증 및 재생성
+    // Rebuild the cached bullet path when the width changed
     if (this.cache.lastCacheW !== canvasW || !this.cache.bulletPath) {
       const path = new Path2D();
       path.arc(0, 0, w, 0.5 * Math.PI, 1.5 * Math.PI);
@@ -396,7 +388,7 @@ export default class Renderer {
       this.cache.lastCacheW = canvasW;
     }
 
-    // (에디터용) 선택된 객체
+    // (editor) selected object
     if (isSelected) {
       ctx.beginPath();
       ctx.font = this.FONT.debug;
@@ -417,21 +409,18 @@ export default class Renderer {
 
       ctx.fillStyle = "#ebd534";
     }
-    // (에디터용) 피격된 개체
+    // (editor) object that was hit
     else if (isHit) {
       ctx.fillStyle = "#fb4934";
     }
-    // 스킨 적용
     else {
       this.#applyStyle(skin.bullet, 0, 0, w, 100, false);
       if (skin.bullet.outline) this.#applyStyle(skin.bullet.outline, 0, 0, w, 100, true);
     }
 
-    // visualAngle 계산
     const visualAngleRad = Math.atan2(getSin(realAngle) * canvasH, getCos(realAngle) * canvasW);
     const visualAngle = (visualAngleRad * 180) / Math.PI;
 
-    // 그리기 시작
     ctx.save();
     ctx.translate(cx, cy);
     ctx.rotate((visualAngle * Math.PI) / 180);
@@ -444,7 +433,7 @@ export default class Renderer {
   }
 
   /**
-   * 트리거로 정의된 텍스트를 그립니다.
+   * Draw the text defined by a trigger.
    * @param {object} textObj - pattern.trigger[i]
    */
   triggerText(textObj) {
@@ -469,7 +458,7 @@ export default class Renderer {
   }
 
   /**
-   * 마우스 커서를 그립니다.
+   * Draw the mouse cursor.
    * @param {object} cursor - { x, y }
    * @param {object} state - { isClicked?, clickedMs? }
    */
@@ -481,18 +470,17 @@ export default class Renderer {
     const { cx, cy } = this.#getPos(mouseX, mouseY);
     const conf = Config.CURSOR;
 
-    // 크기 계산에 필요한 값들 가져오기
     let w = this.CONFIG.CURSOR.SIZE;
     let adder = this.CONFIG.CURSOR.ANIM_SIZE_ADDER;
 
-    // 클릭 애니메이션
+    // Click animation
     if (clickedMs !== undefined && clickedMs !== -1) {
       const now = Date.now();
       if (isClicked) {
-        // 클릭하면 살짝 커짐
+        // grows a little while held
         w = w + adder;
       } else {
-        // 클릭을 풀면 서서히 복귀
+        // eases back after release
         if (now < clickedMs + conf.RELEASE_ANIM_LENGTH) {
           const progress = (clickedMs + conf.RELEASE_ANIM_LENGTH - now) / conf.RELEASE_ANIM_LENGTH;
           w = w + adder * progress;
@@ -503,7 +491,6 @@ export default class Renderer {
     ctx.save();
     ctx.translate(cx, cy);
 
-    // 스킨 적용
     this.#applyStyle(skin.cursor, 0, 0, w, 100, false);
     if (skin.cursor.type === "gradient") ctx.shadowColor = skin.cursor.stops[0].color;
     else ctx.shadowColor = skin.cursor.color;
@@ -514,7 +501,6 @@ export default class Renderer {
       else ctx.shadowColor = skin.cursor.outline.color;
     }
 
-    // 그리기
     ctx.beginPath();
     ctx.arc(0, 0, w, 0, 2 * Math.PI);
     ctx.fill();
@@ -525,8 +511,8 @@ export default class Renderer {
   }
 
   /**
-   * 판정 텍스트를 그립니다.
-   * @param {Array<object>} particles - 판정 파티클 배열
+   * Draw the judgement text.
+   * @param {Array<object>} particles - the judgement particles
    */
   judges(particles) {
     const { ctx, canvasH, skin } = this;
@@ -572,7 +558,7 @@ export default class Renderer {
   }
 
   /**
-   * 클릭 이펙트를 화면에 그립니다.
+   * Draw the click effects.
    * @param {Array<object>} particles
    */
   clickEffects(particles) {
@@ -622,7 +608,7 @@ export default class Renderer {
   }
 
   /**
-   * 폭발 파티클 목록을 업데이트하고 화면에 그립니다.
+   * Update the explosion particles and draw them.
    * @param {Array<object>} particles
    */
   explosions(particles) {
@@ -658,9 +644,9 @@ export default class Renderer {
   }
 
   /**
-   * FC / AP 이펙트를 그립니다.
+   * Draw the FC / AP effect.
    * @param {number} effectNum - 0: AP / 1 : FC
-   * @param {number} effectMs - 이펙트 시작 시간
+   * @param {number} effectMs - when the effect started
    */
   finalEffect(effectNum, effectMs) {
     const { ctx, canvasW, canvasH } = this;
@@ -675,7 +661,7 @@ export default class Renderer {
 
     ctx.save();
 
-    // 1. 배경에 흐르는 텍스트 (화면 모서리 양 끝)
+    // 1. Background text sliding in from both corners
     const backgroundSize = this.CONFIG.FINAL_EFFECT.BACKGROUND.FONT_SIZE;
     const backgroundStartX = this.CONFIG.FINAL_EFFECT.BACKGROUND.START_X;
     const backgroundFinalX = this.CONFIG.FINAL_EFFECT.BACKGROUND.FINAL_X;
@@ -712,7 +698,7 @@ export default class Renderer {
     ctx.textBaseline = "bottom";
     ctx.fillText(text, effectX, effectY);
 
-    // 2. 메인 중앙 텍스트
+    // 2. Main text in the centre
     let mainTextX = ~~(canvasW / 2);
     let mainTextY = ~~(canvasH / 2);
 
@@ -776,27 +762,27 @@ export default class Renderer {
   }
 
   /**
-   * 키 입력 로그 오버레이를 그립니다.
-   * @param {Array} keyInput - 키 입력 데이터 배열
-   * @param {number} keyInputTime - 마지막 키 입력 시간
+   * Draw the key input log overlay.
+   * @param {Array} keyInput - the key input entries
+   * @param {number} keyInputTime - when the last key input happened
    */
   keyInputUI(keyInput, keyInputTime) {
     if (keyInput.length === 0) return;
 
-    // 마지막 입력 후 4초 지났으면 그리지 않음
+    // Nothing is drawn 4 seconds after the last input
     if (keyInput[keyInput.length - 1].time + 4000 <= Date.now()) return;
 
     const { ctx, canvasW, canvasH } = this;
     const now = Date.now();
 
-    // 마지막 입력 후 3초 뒤 페이드 아웃
+    // Fade out starts 3 seconds after the last input
     let alpha = 1;
     if (keyInput[keyInput.length - 1].time + 3000 <= now) {
       alpha = 1 - (now - keyInput[keyInput.length - 1].time - 3000) / 1000;
       if (alpha <= 0) return;
     }
 
-    // 새 입력 발생 시 밀려나는 애니메이션
+    // A new input pushes the row aside
     let animDuration = 0;
     let animX = 0;
     if (keyInputTime + 100 >= now) {
@@ -808,7 +794,7 @@ export default class Renderer {
       let j = i - keyInput.length + 13;
       let partAlpha = alpha;
 
-      // 등장 애니메이션 (투명도)
+      // Fade-in of the entering box
       if (j < 8) {
         partAlpha *= (1 / 8) * (j + animDuration);
       }
@@ -819,7 +805,6 @@ export default class Renderer {
       const judge = keyInput[i].judge;
       let color = KeyInputColors[judge];
 
-      // 박스 그리기
       const boxX = canvasW * 0.08 - canvasH / 15 + (keyInput.length - i - 1) * (canvasW / 100 + canvasW / 200) - animX;
       const boxY = canvasH * 0.05;
       const boxSize = canvasW / 100;
@@ -833,7 +818,6 @@ export default class Renderer {
       ctx.fill();
       ctx.stroke();
 
-      // 텍스트 그리기
       ctx.beginPath();
       ctx.fillStyle = "#fff";
       ctx.font = this.FONT.keyInput;
@@ -850,8 +834,8 @@ export default class Renderer {
   }
 
   /**
-   * 하단 진행도 바 (Progress Bar)를 그립니다.
-   * @param {number} percentage - 진행도 (0 ~ 1)
+   * Draw the progress bar at the bottom.
+   * @param {number} percentage - progress, 0 to 1
    */
   progressBarUI(percentage) {
     const { ctx, canvasW, canvasH } = this;
@@ -874,7 +858,7 @@ export default class Renderer {
   }
 
   /**
-   * 점수판 및 앨범아트 (Score Panel)을 그립니다.
+   * Draw the score panel and the album art.
    * @param {object} data - { score, combo, difficulty }
    * @param {HTMLImageElement} albumImg
    */
@@ -883,17 +867,17 @@ export default class Renderer {
     const { score, combo, difficulty } = data;
     const now = Date.now();
 
-    // 1. 점수 애니메이션 계산
+    // 1. Score animation
     const s = this.animState.score;
 
-    // 실제 점수가 바뀌었으면 목표값 갱신
+    // A changed score becomes the new target
     if (score !== s.target) {
       s.start = s.current;
       s.target = score;
       s.startTime = now;
     }
 
-    // 0.5초간 카운트 업 애니메이션
+    // Counts up over 0.5s
     const scoreElapsed = now - s.startTime;
     if (scoreElapsed < 500) {
       const progress = easeOutQuart(scoreElapsed / 500);
@@ -902,16 +886,16 @@ export default class Renderer {
       s.current = s.target;
     }
 
-    // 2. 콤보 애니메이션 계산
+    // 2. Combo animation
     const c = this.animState.combo;
 
-    // 콤보가 증가했으면 팝업 효과 시작
+    // A higher combo restarts the pop
     if (combo > c.value) {
       c.startTime = now;
     }
     c.value = combo;
 
-    // 0.5초간 팝업 후 서서히 줄어듦
+    // Pops for 0.5s, then shrinks back
     const comboElapsed = now - c.startTime;
     let comboScale = 0;
     if (comboElapsed < 500) {
@@ -921,7 +905,6 @@ export default class Renderer {
     // 3. Rendering
     ctx.save();
 
-    // (1) 배경 박스
     ctx.beginPath();
 
     ctx.fillStyle = DiffColors[difficulty] ?? "#6021ff"; // EZ / MID / HARD / TEST
@@ -938,18 +921,15 @@ export default class Renderer {
     ctx.rect(xBase, yBase, size + padding, size + padding);
     ctx.fill();
 
-    // (2) 흰색 테두리
     ctx.beginPath();
     ctx.fillStyle = "#fff";
     ctx.rect(xBase - border, yBase - border, size + padding, size + padding);
     ctx.fill();
 
-    // (3) 앨범 아트
     if (albumImg) {
       ctx.drawImage(albumImg, xBase, yBase, size, size);
     }
 
-    // (4) 점수 텍스트
     ctx.beginPath();
     ctx.font = this.FONT.scorePanel;
     ctx.textAlign = "right";
@@ -957,7 +937,6 @@ export default class Renderer {
 
     ctx.fillText(numberWithCommas(s.current), xBase - margin, yBase);
 
-    // (5) 콤보 텍스트
     const roundedSize = ~~(this.CONFIG.UI.DEFAULT_FONT_SIZE * (1 + comboScale));
     const roundedWeight = ~~(400 * (1 + comboScale * 0.5));
     ctx.font = `${roundedWeight} ${roundedSize}px Montserrat, Pretendard JP Variable`;
@@ -967,7 +946,7 @@ export default class Renderer {
   }
 
   /**
-   * 시스템 정보를 그립니다.
+   * Draw the system info.
    * @param {object} info - { speed, bpm, fps }
    */
   systemInfoUI(info) {
@@ -982,13 +961,13 @@ export default class Renderer {
     ctx.font = this.FONT.systemInfo;
     ctx.textBaseline = "bottom";
 
-    // Speed & BPM (좌측 하단)
+    // Speed & BPM (bottom left)
     if (speed !== undefined && bpm !== undefined) {
       ctx.textAlign = "left";
       ctx.fillText(`Speed : ${speed}, BPM : ${bpm}`, canvasW / 100, canvasH - canvasH / 60);
     }
 
-    // FPS (우측 하단)
+    // FPS (bottom right)
     if (fps !== undefined) {
       ctx.textAlign = "right";
       ctx.fillText(fps, canvasW - canvasW / 100, canvasH - canvasH / 70);
@@ -997,7 +976,7 @@ export default class Renderer {
     ctx.restore();
   }
 
-  /** 에디터용: 트리거 추가 안내 오버레이를 그립니다. */
+  /** Editor: overlay prompting for a trigger. */
   triggerAddOverlay() {
     const { ctx, canvasW, canvasH } = this;
 
@@ -1025,7 +1004,7 @@ export default class Renderer {
     ctx.restore();
   }
 
-  /** 에디터용: 중앙 십자선을 그립니다. */
+  /** Editor: centre crosshair. */
   axis() {
     const { ctx, canvasW, canvasH } = this;
     const tw = canvasW / 200;
@@ -1033,13 +1012,11 @@ export default class Renderer {
 
     ctx.save();
     ctx.lineWidth = 2;
-    ctx.strokeStyle = "#ed3a2680"; // 붉은색 강조
+    ctx.strokeStyle = "#ed3a2680"; // red accent
     ctx.beginPath();
 
-    // 세로 중앙선
     ctx.moveTo(tw * 100, 0);
     ctx.lineTo(tw * 100, canvasH);
-    // 가로 중앙선
     ctx.moveTo(0, th * 100);
     ctx.lineTo(canvasW, th * 100);
 
@@ -1047,7 +1024,7 @@ export default class Renderer {
     ctx.restore();
   }
 
-  /** 에디터용: 배경 모눈 격자(Mesh Grid)를 그립니다. */
+  /** Editor: background mesh grid. */
   meshGrid() {
     const { ctx, canvasW, canvasH } = this;
     const tw = canvasW / 200;
@@ -1055,21 +1032,19 @@ export default class Renderer {
 
     ctx.save();
     ctx.lineWidth = 2;
-    ctx.strokeStyle = "#bbbbbb20"; // 연한 회색
+    ctx.strokeStyle = "#bbbbbb20"; // light grey
     ctx.beginPath();
 
     let x1 = 0,
       x2 = tw * 5,
       y = 0;
 
-    // 화면 밖 여유분까지 루프
+    // Loops past the screen edges
     for (let i = -100; i <= 100; i += 10) {
-      // 세로선
       ctx.moveTo(x1, 0);
       ctx.lineTo(x1, canvasH);
       ctx.moveTo(x2, 0);
       ctx.lineTo(x2, canvasH);
-      // 가로선
       ctx.moveTo(0, y);
       ctx.lineTo(canvasW, y);
 
@@ -1082,8 +1057,8 @@ export default class Renderer {
   }
 
   /**
-   * 에디터용: 방사형 그리드(Radial Grid)를 그립니다.
-   * @param {object} centerNote - pattern.patterns[i] (중심이 될 노트)
+   * Editor: radial grid.
+   * @param {object} centerNote - pattern.patterns[i], the note at the centre
    */
   radialGrid(centerNote) {
     const { ctx, canvasW } = this;
@@ -1103,7 +1078,7 @@ export default class Renderer {
   }
 
   /**
-   * 에디터용: 노트 연결선을 그립니다.
+   * Editor: connector line between notes.
    * @param {object} prevNote - { x, y }
    * @param {object} currNote - { x, y }
    * @param {number} alpha - 0 ~ 255
@@ -1122,9 +1097,9 @@ export default class Renderer {
   }
 
   /**
-   * 에디터용: 지나간 노트의 그림자(잔상)를 그립니다.
+   * Editor: ghost of a note that already passed.
    * @param {object} note - { x, y, value, direction }
-   * @param {number} alpha - 투명도
+   * @param {number} alpha - opacity
    */
   noteShadow(note, alpha) {
     const { ctx } = this;

--- a/public/modules/socket.js
+++ b/public/modules/socket.js
@@ -1,10 +1,7 @@
 /* global io, iziToast, game, lang, alias, socketi18n */
+import { escapeHtml } from "./utils.js";
+
 const body = document.querySelector("body");
-// Shared from modules/utils.js (this is a classic script, so import dynamically).
-let escapeHtml = (value) => String(value ?? "");
-import("./utils.js").then((utils) => {
-  escapeHtml = utils.escapeHtml;
-});
 let isErrorOccured = false;
 let achievementCount = 0;
 const socket = io(game, {

--- a/public/modules/socket.js
+++ b/public/modules/socket.js
@@ -4,9 +4,12 @@ import { escapeHtml } from "./utils.js";
 const body = document.querySelector("body");
 let isErrorOccured = false;
 let achievementCount = 0;
-const socket = io(game, {
+export const socket = io(game, {
   withCredentials: true,
 });
+
+// The one place this module is exposed to the classic scripts, which cannot import it.
+(window.URLATE ??= {}).socket = socket;
 
 document.addEventListener("DOMContentLoaded", () => {
   const img = new Image();

--- a/public/modules/updater.js
+++ b/public/modules/updater.js
@@ -1,17 +1,17 @@
 /**
  * updater.js
- * 게임의 데이터 계산, 물리 연산, 수명 관리 등 핵심 로직을 담당합니다.
+ * Core logic: data, physics and lifetime management.
  */
 import { getSin, getCos, upperBound, lowerBound } from "./utils.js";
 import Factory from "./factory.js";
 
 export default class Updater {
   /**
-   * 총알의 현재 위치(x, y)와 각도를 계산합니다.
-   * @param {object} bullet - 총알 데이터 객체
-   * @param {number} currentBeat - 현재 곡의 비트(beats)
-   * @param {Array} triggers - 트리거 배열 (변속 등을 계산하기 위함)
-   * @param {number} baseSpeed - 곡의 기본 스피드
+   * Current position (x, y) and angle of a bullet.
+   * @param {object} bullet - bullet data
+   * @param {number} currentBeat - the song's current beat
+   * @param {Array} triggers - triggers, needed for the speed changes
+   * @param {number} baseSpeed - the song's base speed
    * @returns {{x: number, y: number, angle: number}}
    */
   static bulletPos(bullet, currentBeat, triggers, baseSpeed, creationSpeed = null) {
@@ -20,12 +20,12 @@ export default class Updater {
     let triggerEnd;
 
     if (creationSpeed !== null) {
-      // 호출자가 생성 시점 속도를 미리 계산해서 전달 — 첫 번째 탐색 생략
+      // The caller already worked out the speed at spawn time, so skip the first search
       currentSpeed = creationSpeed;
       triggerStart = lowerBound(triggers, bullet.beat);
       triggerEnd = upperBound(triggers, currentBeat);
     } else {
-      // 폴백: 기존 방식으로 생성 시점 속도 계산
+      // Fallback: work out the speed at spawn time the old way
       triggerEnd = upperBound(triggers, bullet.beat);
       currentSpeed = baseSpeed;
       for (let i = 0; i < triggerEnd; i++) {
@@ -39,18 +39,17 @@ export default class Updater {
     let prevBeat = bullet.beat;
     let prevSpeed = currentSpeed;
 
-    // 변속 구간 누적 계산
     for (let j = triggerStart; j < triggerEnd; j++) {
       const trigger = triggers[j];
       if (trigger.value == 4) {
-        // (거리 = 시간 * 속도) 개념의 비트 기반 계산
+        // distance = time * speed, counted in beats
         p += ((trigger.beat - prevBeat) * prevSpeed * bullet.speed) / 0.15;
         prevBeat = trigger.beat;
         prevSpeed = trigger.speed;
       }
     }
 
-    // 현재 비트까지의 남은 거리 추가
+    // Remaining distance up to the current beat
     p += ((currentBeat - prevBeat) * prevSpeed * bullet.speed) / 0.15;
 
     const isLeft = bullet.direction == "L";
@@ -63,10 +62,10 @@ export default class Updater {
   }
 
   /**
-   * 노트의 현재 진행 상태(progress)를 계산합니다.
-   * @param {object} note - 노트 데이터
-   * @param {number} currentBeat - 현재 비트
-   * @param {number} speed - 현재 속도 (배속)
+   * Progress of a note.
+   * @param {object} note - note data
+   * @param {number} currentBeat - the current beat
+   * @param {number} speed - the current speed multiplier
    * @returns {{progress: number, tailProgress: number, endProgress: number}}
    */
   static noteProgress(note, currentBeat, speed, out) {
@@ -79,9 +78,9 @@ export default class Updater {
   }
 
   /**
-   * 수명이 다한 파티클을 배열에서 제거하고 풀로 반환합니다.
-   * @param {Array} particles - 파티클 배열
-   * @param {object} [hideSettings] - 판정 숨김 설정 (judgeParticles 관리시에만 필요)
+   * Drop the particles that reached the end of their life and return them to the pool.
+   * @param {Array} particles - the particles
+   * @param {object} [hideSettings] - judgement hiding settings, only for judgeParticles
    */
   static particles(particles, hideSettings = null) {
     const now = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,13 @@ import cookieParser from "cookie-parser";
 import express, { NextFunction, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 import i18n from "./i18n";
-import multer from "multer";
-import path from "path";
 import fetch from "node-fetch";
 import { exec } from "child_process";
-import * as tf from "@tensorflow/tfjs";
-import "@tensorflow/tfjs-backend-wasm";
-import * as nsfw from "nsfwjs";
-import fs from "fs";
-import sharp from "sharp";
 import { logger } from "./logger";
 import { errorHandler, notFoundHandler, sendError } from "./middleware";
+import { initProfile, profileRouter } from "./profile";
 import { URL } from "url";
-import { createHash, randomUUID } from "crypto";
+import { createHash } from "crypto";
 
 let branch;
 exec("git branch --show-current", (err, stdout, stderr) => {
@@ -29,15 +23,13 @@ const config = require(__dirname + "/../config/config.json");
 
 const version = require(__dirname + "/../package.json").version;
 
-let model;
-
 // node-fetch has no default timeout: a hung backend would pin the request handler.
 const API_TIMEOUT_MS = 5000;
 
 const app = express();
 app.locals.pretty = true;
 
-// 버전 노출을 막습니다.
+// Do not advertise the framework version.
 app.disable("x-powered-by");
 
 // Rate limiting keys on the client address, which arrives via X-Forwarded-For.
@@ -138,18 +130,6 @@ const gateLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 30,
   skip: (req) => !!req.headers.cookie && readCachedStatus(authCacheKey(req.headers.cookie)) !== null,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-/**
- * An upload costs a 3MB write, a sharp re-encode and an NSFW inference, and the
- * file it leaves behind is served from our own origin. Cheap for the caller,
- * expensive for us -- so it gets a budget of its own, well below the gate's.
- */
-const uploadLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 10,
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -318,309 +298,12 @@ app.get("/privacy", (req, res) => {
   res.render("privacy");
 });
 
-// 업로드된 프로필 이미지가 놓이는 유일한 위치입니다. 아래 세 곳이 각자
-// 다른 방식으로 같은 경로를 만들고 있어 하나로 모았습니다.
-const PROFILES_DIR = path.resolve(__dirname, "..", "public", "images", "profiles");
+app.use(profileRouter);
 
-/**
- * 프로필 디렉터리 "안의 파일"일 때만 정규화한 절대 경로를 돌려줍니다. 벗어나거나
- * 디렉터리 자기 자신이면 null입니다. 삭제처럼 되돌릴 수 없는 동작 앞에 꼭
- * 거쳐야 합니다.
- */
-const insideProfiles = (candidate: string): string | null => {
-  const resolved = path.resolve(PROFILES_DIR, candidate);
-  return resolved.startsWith(PROFILES_DIR + path.sep) ? resolved : null;
-};
-
-const upload = multer({
-  storage: multer.diskStorage({
-    destination: function (req, file, cb) {
-      const dirPath = PROFILES_DIR;
-      fs.mkdir(dirPath, { recursive: true }, (err) => {
-        if (err) {
-          logger.error("Profile update API error", err, {
-            message: "Failed to create profile image directory.",
-            userid: req.params.userid,
-          });
-          return cb(err, dirPath);
-        }
-        cb(null, dirPath);
-      });
-    },
-    // Date.now() alone collides: two uploads in the same millisecond overwrite
-    // each other's image.
-    filename: function (req, file, cb) {
-      cb(null, `${Date.now()}-${randomUUID()}.webp`);
-    },
-  }),
-  limits: {
-    fileSize: 3 * 1024 * 1024, // 3MB
-  },
-  // Rejecting here keeps a non-image from ever reaching the disk; the handler's
-  // own check runs after multer has already written the file.
-  fileFilter: function (req, file, cb) {
-    cb(null, file.mimetype.indexOf("image") === 0);
-  },
-}).single("img");
-
-// multer writes the upload to disk before the handler runs, so every path that
-// rejects the request afterwards has to remove it or the bytes stay forever.
-const discardUpload = (file: Express.Multer.File | undefined) => {
-  if (!file?.path) return;
-  // 파일명은 서버가 만들지만, 지우는 동작이므로 경로를 다시 확인합니다.
-  const target = insideProfiles(file.path);
-  if (!target) {
-    logger.error("Refused to remove a file outside the profiles directory", null, { path: file.path });
-    return;
-  }
-  fs.promises.unlink(target).catch((err) => {
-    if (err.code !== "ENOENT") logger.warn("Failed to remove a rejected upload", { path: target, error: err });
-  });
-};
-
-const imageToTensor = async (fileBuffer) => {
-  const { data, info } = await sharp(fileBuffer).raw().toBuffer({ resolveWithObject: true });
-
-  return tf.tensor3d(new Uint8Array(data), [info.height, info.width, info.channels], "int32");
-};
-
-/**
- * Resolve the caller's identity from the backend session.
- *
- * This route supplies the backend's project secret on the caller's behalf, so
- * the `:userid` path segment must never be trusted. The browser already sends
- * its session cookie here, so forward it and let the backend session decide.
- */
-const resolveSessionUserid = async (req): Promise<string | null> => {
-  if (!req.headers.cookie) return null;
-  try {
-    const response = await fetch(`${config.project.api}/user`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Cookie: req.headers.cookie,
-      },
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
-    });
-    if (!response.ok) return null;
-    const data: any = await response.json();
-    if (data.result !== "success" || !data.user || !data.user.userid) return null;
-    return String(data.user.userid);
-  } catch (err) {
-    logger.warn("Failed to resolve session userid", { error: err });
-    return null;
-  }
-};
-
-app.post("/profile/:userid/:type", uploadLimiter, async (req, res) => {
-  // Validate userid: must be numeric
-  if (!/^[0-9]+$/.test(req.params.userid)) {
-    res.status(400).json({
-      result: "failed",
-      message: "Invalid userid format",
-      error: "Bad userid",
-    });
-    return;
-  }
-
-  // Authenticate before multer, sharp and the NSFW model spend any work.
-  const sessionUserid = await resolveSessionUserid(req);
-  if (!sessionUserid) {
-    res.status(401).json({
-      result: "failed",
-      message: "Login required",
-      error: "Unauthorized",
-    });
-    return;
-  }
-  if (sessionUserid !== req.params.userid) {
-    logger.warn("Rejected profile upload for a different user", {
-      sessionUserid,
-      requested: req.params.userid,
-    });
-    res.status(403).json({
-      result: "failed",
-      message: "You can only update your own profile",
-      error: "Forbidden",
-    });
-    return;
-  }
-
-  let type = "";
-  let width = 256;
-  let height = 256;
-  if (req.params.type == "picture") {
-    type = "picture";
-  } else if (req.params.type == "background") {
-    width = 2560;
-    height = null;
-    type = "background";
-  } else {
-    res.status(400).json({
-      result: "failed",
-      message: "Error occured while uploading",
-      error: "Invalid type",
-    });
-    return;
-  }
-
-  // Fetch existing profile/background URL before upload
-  let oldFileUrl: string | null = null;
-  try {
-    const profileResponse = await fetch(`${config.project.api}/profile/${req.params.userid}`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
-    });
-    const profileData: any = await profileResponse.json();
-    if (profileData.result === "success" && profileData.user && profileData.user[type] && !config.project.ignoredImageURL.some((domain) => profileData.user[type].includes(domain))) {
-      oldFileUrl = profileData.user[type];
-    }
-  } catch (err) {
-    logger.warn("Failed to fetch existing profile data", { userid: req.params.userid, type, error: err });
-  }
-
-  upload(req, res, async (err) => {
-    if (err) {
-      if (err instanceof multer.MulterError) err = err.message;
-      else err = err.code;
-      discardUpload(req.file);
-      logger.error("File upload error", err, { userid: req.params.userid, type: req.params.type });
-      res.status(400).json({
-        result: "failed",
-        message: "Error occured while uploading",
-        error: err,
-      });
-      return;
-    }
-    const file = req.file;
-    if (!file || file.mimetype.indexOf("image") == -1) {
-      discardUpload(file);
-      logger.warn("Invalid file upload attempt", { userid: req.params.userid, type: req.params.type, mimetype: file?.mimetype });
-      res.status(400).json({
-        result: "failed",
-        message: "Error occured while uploading",
-        error: "Invalid file type",
-      });
-      return;
-    }
-    const filePath = insideProfiles(file.path);
-    if (!filePath) {
-      discardUpload(file);
-      logger.error("Path traversal attempt detected", null, { userid: req.params.userid, path: file.path });
-      res.status(400).json({
-        result: "failed",
-        message: "Error occured while uploading",
-        error: "Invalid file path",
-      });
-      return;
-    }
-
-    // multer's callback is not an Express handler, so a rejection here is not
-    // turned into a response -- the request would hang and the file would stay.
-    let fileBuffer: Buffer;
-    let explicit = false;
-    try {
-      fileBuffer = await sharp(filePath)
-        .resize({ width, height })
-        .flatten({ background: "#ffffff" })
-        .webp({
-          quality: 70,
-          effort: 6,
-        })
-        .toBuffer();
-      fs.writeFileSync(filePath, fileBuffer);
-      const image = await imageToTensor(fileBuffer);
-      const predictions = await model.classify(image);
-      image.dispose();
-      if (predictions[0].className != "Drawing" && predictions[0].className != "Neutral") explicit = true;
-    } catch (e) {
-      discardUpload(file);
-      logger.error("Failed to process the uploaded image", e, { userid: req.params.userid, type: req.params.type });
-      res.status(400).json({
-        result: "failed",
-        message: "Error occured while uploading",
-        error: "Invalid image",
-      });
-      return;
-    }
-
-    fetch(`${config.project.api}/profile/${type}`, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
-      body: JSON.stringify({
-        explicit,
-        // Verified against the backend session, never the raw path segment.
-        userid: sessionUserid,
-        value: `${config.project.url}/images/profiles/${file.filename}`,
-        secret: config.project.secretKey,
-      }),
-    })
-      .then((res) => res.json())
-      .then((json: any) => {
-        if (json.result == "failed") {
-          discardUpload(file);
-          logger.error("Profile update API error", null, { message: json.message, userid: req.params.userid });
-          res.status(400).json({
-            result: "failed",
-            message: "Error occured while uploading",
-            error: json.message,
-          });
-          return;
-        }
-
-        // Delete old file after successful upload
-        if (oldFileUrl) {
-          // Asynchronously delete the old file without blocking the response.
-          (async () => {
-            try {
-              const oldFilename = path.basename(new URL(oldFileUrl).pathname);
-              const oldFilePath = insideProfiles(oldFilename);
-
-              if (oldFilePath) {
-                await fs.promises.unlink(oldFilePath);
-                logger.info(`Deleted old ${type} file`, { userid: req.params.userid, oldFilename });
-              } else {
-                logger.warn("Skipping deletion of file outside the root directory.", { userid: req.params.userid, oldFileUrl });
-              }
-            } catch (err) {
-              // It's okay if the file doesn't exist. Log other errors.
-              if (err.code !== "ENOENT") {
-                logger.warn(`Failed to delete old ${type} file`, { userid: req.params.userid, oldFileUrl, error: err });
-              }
-            }
-          })();
-        }
-
-        res.status(200).json({ result: "success", url: `${config.project.url}/images/profiles/${file.filename}`, explicit });
-      })
-      .catch((err) => {
-        discardUpload(file);
-        logger.error("Profile update fetch error", err, { userid: req.params.userid });
-        res.status(500).json({
-          result: "failed",
-          message: "Error occured while uploading",
-          error: "Internal server error",
-        });
-      });
-  });
-});
-
-const loadModel = async () => {
-  model = await nsfw.load(`${config.project.nsfw}/mobilenet_v2/`);
-};
-
-// Handle unhandled promise rejections
 process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
   logger.fatal("Unhandled Promise Rejection", reason, { promise: promise.toString() });
 });
 
-// Handle uncaught exceptions
 process.on("uncaughtException", (error: Error) => {
   logger.fatal("Uncaught Exception", error);
   process.exit(1);
@@ -628,10 +311,7 @@ process.on("uncaughtException", (error: Error) => {
 
 (async () => {
   try {
-    await tf.setBackend("wasm");
-    await tf.ready();
-
-    await loadModel();
+    await initProfile();
 
     app.listen(config.project.port, () => {
       logger.info(`URLATE-v3l-frontend is running on version ${config.project.mode == "test" ? Date.now() : version}.`);
@@ -643,8 +323,8 @@ process.on("uncaughtException", (error: Error) => {
   }
 })();
 
-// 라우트 뒤에 와야 합니다. 앞에 두면 모든 요청이 404로 끝납니다.
+// Must come after the routes: placed earlier, every request would end in a 404.
 app.use(notFoundHandler);
 
-// Add error handler middleware (must be last)
+// Must be last.
 app.use(errorHandler);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,26 +2,24 @@ import signale from "signale";
 import fs from "fs";
 import path from "path";
 
-// Create logs directory if it doesn't exist
 const logsDir = path.join(__dirname, "../logs");
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }
 
-// Log file paths
 const errorLogPath = path.join(logsDir, "error.log");
 const combinedLogPath = path.join(logsDir, "combined.log");
 
-// 로그 회전 기준입니다. 배포가 logs/를 지우지 않으므로 스스로 정리해야
-// 디스크가 찹니다. 파일당 상한 x (원본 + 보관본) 만큼만 남습니다.
+// Rotation bounds. A deploy does not clear logs/, so the logs have to trim
+// themselves or the disk fills up. At most (limit per file) x (live + kept) remains.
 const MAX_LOG_BYTES = 10 * 1024 * 1024;
 const KEEP_ROTATIONS = 3;
 
-// 매 줄마다 stat을 부르지 않도록 크기를 기억해 둡니다.
+// Remembered so a stat is not needed for every line written.
 const knownSizes = new Map<string, number>();
 
 /**
- * 파일을 .1 로 밀어내고 가장 오래된 보관본을 지웁니다.
+ * Shift the file down to .1 and drop the oldest kept copy.
  */
 function rotate(filePath: string): void {
   const oldest = `${filePath}.${KEEP_ROTATIONS}`;
@@ -59,7 +57,7 @@ function writeToFile(filePath: string, content: string): void {
     fs.appendFileSync(filePath, content, "utf8");
     knownSizes.set(filePath, size + bytes);
   } catch (err) {
-    // 로그를 남기지 못하는 것이 요청을 실패시켜서는 안 됩니다.
+    // Failing to log must never fail the request.
     console.error("Failed to write to log file:", err);
   }
 }
@@ -133,5 +131,4 @@ class Logger {
   }
 }
 
-// Export singleton instance
 export const logger = new Logger();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,14 +2,14 @@ import { Request, Response, NextFunction } from "express";
 import { logger } from "./logger";
 
 /**
- * i18n 미들웨어가 심어 둔 번역 함수를 씁니다. 오류 처리는 그 미들웨어보다
- * 앞에서도 불릴 수 있으므로, 없으면 영어 문구로 되돌아갑니다.
+ * Uses the translation function the i18n middleware installs. Error handling can
+ * run before that middleware, so fall back to the English text when it is absent.
  */
 const translate = (res: Response, key: string, fallback: string): string => {
   const __ = res.locals.__;
   if (typeof __ !== "function") return fallback;
   const translated = __(key);
-  // i18n은 정의되지 않은 키를 그대로 돌려줍니다.
+  // i18n returns an undefined key unchanged.
   return translated === key ? fallback : translated;
 };
 
@@ -32,10 +32,10 @@ const MESSAGES: Record<number, { key: string; title: string; description: string
 };
 
 /**
- * 상태 코드에 맞는 오류 응답을 보냅니다.
+ * Send the error response for a status code.
  *
- * 브라우저 내비게이션에는 화면을, 그 밖에는 JSON을 돌려줍니다. 이 서버는
- * 페이지와 업로드 API를 함께 제공하므로 한쪽 형식으로 고정할 수 없습니다.
+ * Browser navigations get a page, everything else gets JSON: this server serves
+ * both pages and the upload API, so neither format can be the only one.
  */
 export const sendError = (req: Request, res: Response, status: number): void => {
   const message = MESSAGES[status] ?? MESSAGES[500];
@@ -43,8 +43,8 @@ export const sendError = (req: Request, res: Response, status: number): void => 
   const description = translate(res, `${message.key}_desc`, message.description);
 
   res.status(status);
-  // req.accepts는 Accept 헤더 순서를 존중합니다. fetch/XHR은 보통 JSON을
-  // 먼저 요구하므로 화면 대신 JSON을 받게 됩니다.
+  // req.accepts honours the order of the Accept header. fetch/XHR usually asks
+  // for JSON first, so they get JSON instead of the page.
   if (req.accepts(["html", "json"]) === "html") {
     res.render(
       "error",
@@ -56,7 +56,7 @@ export const sendError = (req: Request, res: Response, status: number): void => 
         locale: res.locals.locale ?? "en",
       },
       (err, html) => {
-        // 뷰 렌더링까지 실패하면 최소한의 응답이라도 보냅니다.
+        // If even the view fails, send the barest response we can.
         if (err) {
           logger.error("Failed to render the error page", err, { status });
           res.type("text").send(`${status} ${title}`);
@@ -70,7 +70,7 @@ export const sendError = (req: Request, res: Response, status: number): void => 
   res.json({ result: "failed", message: title, error: description });
 };
 
-// 알 수 없는 경로입니다. 라우터 뒤, errorHandler 앞에 두어야 합니다.
+// Unknown path. Must sit after the routes and before errorHandler.
 export function notFoundHandler(req: Request, res: Response): void {
   sendError(req, res, 404);
 }
@@ -80,7 +80,6 @@ export function notFoundHandler(req: Request, res: Response): void {
  * Logs errors and sends appropriate responses
  */
 export function errorHandler(err: any, req: Request, res: Response, next: NextFunction): void {
-  // Log the error with request context
   logger.error("Request error occurred", err, {
     method: req.method,
     url: req.url,
@@ -91,11 +90,12 @@ export function errorHandler(err: any, req: Request, res: Response, next: NextFu
     userAgent: req.get("user-agent"),
   });
 
-  // 헤더가 이미 나갔으면 응답을 덧붙일 수 없습니다. 연결을 끊는 것이 맞습니다.
+  // Once the headers are out nothing can be added; dropping the connection is right.
   if (res.headersSent) return next(err);
 
-  // 스택은 절대 응답에 싣지 않습니다. 절대 경로와 의존성 버전이 담겨 있고,
-  // pm2 설정에 NODE_ENV가 없어 그것으로 분기하면 운영에서도 노출됩니다.
+  // The stack never goes into a response: it carries absolute paths and dependency
+  // versions, and the pm2 config sets no NODE_ENV, so branching on that would leak
+  // it in production too.
   const statusCode = err.statusCode || err.status || 500;
   sendError(req, res, statusCode >= 400 && statusCode < 600 ? statusCode : 500);
 }

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,0 +1,381 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import multer from "multer";
+import path from "path";
+import fetch from "node-fetch";
+import * as tf from "@tensorflow/tfjs";
+import "@tensorflow/tfjs-backend-wasm";
+import * as nsfw from "nsfwjs";
+import fs from "fs";
+import sharp from "sharp";
+import { logger } from "./logger";
+import { URL } from "url";
+import { randomUUID } from "crypto";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const config = require(__dirname + "/../config/config.json");
+
+// node-fetch has no default timeout: a hung backend would pin the request handler.
+const API_TIMEOUT_MS = 5000;
+
+let model;
+
+/**
+ * An upload costs a 3MB read, a sharp re-encode, an NSFW inference and a push to
+ * the CDN storage zone. Cheap for the caller, expensive for us -- so it gets a
+ * budget of its own, well below the gate's.
+ */
+const uploadLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// New uploads all go to BunnyCDN. This directory only exists to serve and delete
+// the files that were uploaded before the move.
+const PROFILES_DIR = path.resolve(__dirname, "..", "public", "images", "profiles");
+
+// Returns the resolved path only for a file inside the profiles directory, and
+// null for anything that escapes it. Required before an unlink.
+const insideProfiles = (candidate: string): string | null => {
+  const resolved = path.resolve(PROFILES_DIR, candidate);
+  return resolved.startsWith(PROFILES_DIR + path.sep) ? resolved : null;
+};
+
+const BUNNY_PATH = String(config.bunny?.path ?? "profiles").replace(/^\/+|\/+$/g, "");
+
+// A storage upload pushes up to 3MB over the network, so it needs more room than
+// a backend call.
+const BUNNY_TIMEOUT_MS = 15000;
+
+// Only files we uploaded may be deleted. A name that does not match may be a
+// default image or an avatar we do not own. The legacy form predates the UUID
+// suffix and exists on disk only.
+const PROFILE_FILENAME = /^[0-9]+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.webp$/;
+const LEGACY_PROFILE_FILENAME = /^[0-9]+\.webp$/;
+
+const bunnyStorageUrl = (filename: string) => `https://${config.bunny.endpoint}/${config.bunny.storageZone}/${BUNNY_PATH}/${filename}`;
+
+// The address browsers fetch: a pull zone sits in front of the storage zone.
+const bunnyPublicUrl = (filename: string) => `${config.project.cdn}/${BUNNY_PATH}/${filename}`;
+
+const uploadToBunny = async (filename: string, buffer: Buffer) => {
+  const response = await fetch(bunnyStorageUrl(filename), {
+    method: "PUT",
+    headers: {
+      AccessKey: config.bunny.accessKey,
+      "Content-Type": "image/webp",
+    },
+    body: buffer,
+    signal: AbortSignal.timeout(BUNNY_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`BunnyCDN storage responded with ${response.status}`);
+};
+
+const deleteFromBunny = async (filename: string) => {
+  const response = await fetch(bunnyStorageUrl(filename), {
+    method: "DELETE",
+    headers: { AccessKey: config.bunny.accessKey },
+    signal: AbortSignal.timeout(BUNNY_TIMEOUT_MS),
+  });
+  // A file that is already gone answers 404, which is the state we wanted.
+  if (!response.ok && response.status !== 404) throw new Error(`BunnyCDN storage responded with ${response.status}`);
+};
+
+// Once the file is in the storage zone, a later failure would leave it there
+// unreferenced. Clean up behind the response instead of holding it.
+const discardUpload = (filename: string | null, context: Record<string, unknown>) => {
+  if (!filename) return;
+  deleteFromBunny(filename).catch((err) => {
+    logger.warn("Failed to remove a rejected upload from BunnyCDN", { ...context, filename, error: err });
+  });
+};
+
+// Tells where a previous profile URL lives, but only when we uploaded it.
+// Default images and external avatars return null and are left alone.
+const locateOldFile = (fileUrl: string): { kind: "bunny" | "local"; filename: string } | null => {
+  const bunnyPrefix = `${config.project.cdn}/${BUNNY_PATH}/`;
+  const localPrefix = `${config.project.url}/images/profiles/`;
+  const kind = fileUrl.startsWith(bunnyPrefix) ? "bunny" : fileUrl.startsWith(localPrefix) ? "local" : null;
+  if (!kind) return null;
+  let filename: string;
+  try {
+    filename = path.basename(new URL(fileUrl).pathname);
+  } catch {
+    return null;
+  }
+  if (!PROFILE_FILENAME.test(filename) && !(kind === "local" && LEGACY_PROFILE_FILENAME.test(filename))) return null;
+  return { kind, filename };
+};
+
+const upload = multer({
+  // The file never touches the disk: sharp reads the buffer and only the result
+  // is pushed to the storage zone.
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 3 * 1024 * 1024, // 3MB
+  },
+  // Rejecting here keeps a non-image from ever being buffered; the handler's
+  // own check runs after multer has already read the file.
+  fileFilter: function (req, file, cb) {
+    cb(null, file.mimetype.indexOf("image") === 0);
+  },
+}).single("img");
+
+const imageToTensor = async (fileBuffer) => {
+  const { data, info } = await sharp(fileBuffer).raw().toBuffer({ resolveWithObject: true });
+
+  return tf.tensor3d(new Uint8Array(data), [info.height, info.width, info.channels], "int32");
+};
+
+/**
+ * Resolve the caller's identity from the backend session.
+ *
+ * This route supplies the backend's project secret on the caller's behalf, so
+ * the `:userid` path segment must never be trusted. The browser already sends
+ * its session cookie here, so forward it and let the backend session decide.
+ */
+const resolveSessionUserid = async (req): Promise<string | null> => {
+  if (!req.headers.cookie) return null;
+  try {
+    const response = await fetch(`${config.project.api}/user`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: req.headers.cookie,
+      },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const data: any = await response.json();
+    if (data.result !== "success" || !data.user || !data.user.userid) return null;
+    return String(data.user.userid);
+  } catch (err) {
+    logger.warn("Failed to resolve session userid", { error: err });
+    return null;
+  }
+};
+
+const assertBunnyConfig = () => {
+  const missing = ["endpoint", "storageZone", "accessKey"].filter((key) => !config.bunny?.[key]);
+  if (missing.length) throw new Error(`Missing BunnyCDN storage config: bunny.${missing.join(", bunny.")}`);
+};
+
+// Config check and model load have to finish before the server accepts traffic:
+// learning about a broken storage config on the first upload is too late.
+export const initProfile = async () => {
+  assertBunnyConfig();
+
+  await tf.setBackend("wasm");
+  await tf.ready();
+
+  model = await nsfw.load(`${config.project.nsfw}/mobilenet_v2/`);
+};
+
+export const profileRouter = Router();
+
+profileRouter.post("/profile/:userid/:type", uploadLimiter, async (req, res) => {
+  if (!/^[0-9]+$/.test(req.params.userid)) {
+    res.status(400).json({
+      result: "failed",
+      message: "Invalid userid format",
+      error: "Bad userid",
+    });
+    return;
+  }
+
+  // Authenticate before multer, sharp and the NSFW model spend any work.
+  const sessionUserid = await resolveSessionUserid(req);
+  if (!sessionUserid) {
+    res.status(401).json({
+      result: "failed",
+      message: "Login required",
+      error: "Unauthorized",
+    });
+    return;
+  }
+  if (sessionUserid !== req.params.userid) {
+    logger.warn("Rejected profile upload for a different user", {
+      sessionUserid,
+      requested: req.params.userid,
+    });
+    res.status(403).json({
+      result: "failed",
+      message: "You can only update your own profile",
+      error: "Forbidden",
+    });
+    return;
+  }
+
+  let type = "";
+  let width = 256;
+  let height = 256;
+  if (req.params.type == "picture") {
+    type = "picture";
+  } else if (req.params.type == "background") {
+    width = 2560;
+    height = null;
+    type = "background";
+  } else {
+    res.status(400).json({
+      result: "failed",
+      message: "Error occured while uploading",
+      error: "Invalid type",
+    });
+    return;
+  }
+
+  let oldFileUrl: string | null = null;
+  try {
+    const profileResponse = await fetch(`${config.project.api}/profile/${req.params.userid}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    const profileData: any = await profileResponse.json();
+    if (profileData.result === "success" && profileData.user && profileData.user[type]) {
+      oldFileUrl = profileData.user[type];
+    }
+  } catch (err) {
+    logger.warn("Failed to fetch existing profile data", { userid: req.params.userid, type, error: err });
+  }
+
+  upload(req, res, async (err) => {
+    if (err) {
+      if (err instanceof multer.MulterError) err = err.message;
+      else err = err.code;
+      logger.error("File upload error", err, { userid: req.params.userid, type: req.params.type });
+      res.status(400).json({
+        result: "failed",
+        message: "Error occured while uploading",
+        error: err,
+      });
+      return;
+    }
+    const file = req.file;
+    if (!file || file.mimetype.indexOf("image") == -1) {
+      logger.warn("Invalid file upload attempt", { userid: req.params.userid, type: req.params.type, mimetype: file?.mimetype });
+      res.status(400).json({
+        result: "failed",
+        message: "Error occured while uploading",
+        error: "Invalid file type",
+      });
+      return;
+    }
+
+    // multer's callback is not an Express handler, so a rejection here is not
+    // turned into a response -- the request would hang.
+    let fileBuffer: Buffer;
+    let explicit = false;
+    try {
+      fileBuffer = await sharp(file.buffer)
+        .resize({ width, height })
+        .flatten({ background: "#ffffff" })
+        .webp({
+          quality: 70,
+          effort: 6,
+        })
+        .toBuffer();
+      const image = await imageToTensor(fileBuffer);
+      const predictions = await model.classify(image);
+      image.dispose();
+      if (predictions[0].className != "Drawing" && predictions[0].className != "Neutral") explicit = true;
+    } catch (e) {
+      logger.error("Failed to process the uploaded image", e, { userid: req.params.userid, type: req.params.type });
+      res.status(400).json({
+        result: "failed",
+        message: "Error occured while uploading",
+        error: "Invalid image",
+      });
+      return;
+    }
+
+    // Date.now() alone collides: two uploads in the same millisecond overwrite
+    // each other's image.
+    const filename = `${Date.now()}-${randomUUID()}.webp`;
+    try {
+      await uploadToBunny(filename, fileBuffer);
+    } catch (e) {
+      logger.error("Failed to upload the image to BunnyCDN", e, { userid: req.params.userid, type: req.params.type, filename });
+      res.status(502).json({
+        result: "failed",
+        message: "Error occured while uploading",
+        error: "Storage upload failed",
+      });
+      return;
+    }
+
+    const publicUrl = bunnyPublicUrl(filename);
+
+    fetch(`${config.project.api}/profile/${type}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      body: JSON.stringify({
+        explicit,
+        // Verified against the backend session, never the raw path segment.
+        userid: sessionUserid,
+        value: publicUrl,
+        secret: config.project.secretKey,
+      }),
+    })
+      .then((res) => res.json())
+      .then((json: any) => {
+        if (json.result == "failed") {
+          discardUpload(filename, { userid: req.params.userid, type: req.params.type });
+          logger.error("Profile update API error", null, { message: json.message, userid: req.params.userid });
+          res.status(400).json({
+            result: "failed",
+            message: "Error occured while uploading",
+            error: json.message,
+          });
+          return;
+        }
+
+        if (oldFileUrl) {
+          // Delete the old file without blocking the response.
+          (async () => {
+            const old = locateOldFile(oldFileUrl);
+            if (!old) {
+              logger.info(`Kept the previous ${type} image, which we did not upload`, { userid: req.params.userid, oldFileUrl });
+              return;
+            }
+            try {
+              if (old.kind === "bunny") {
+                await deleteFromBunny(old.filename);
+              } else {
+                const oldFilePath = insideProfiles(old.filename);
+                if (!oldFilePath) {
+                  logger.warn("Skipping deletion of file outside the root directory.", { userid: req.params.userid, oldFileUrl });
+                  return;
+                }
+                await fs.promises.unlink(oldFilePath);
+              }
+              logger.info(`Deleted old ${type} file`, { userid: req.params.userid, oldFilename: old.filename, storage: old.kind });
+            } catch (err) {
+              // It's okay if the file doesn't exist. Log other errors.
+              if (err.code !== "ENOENT") {
+                logger.warn(`Failed to delete old ${type} file`, { userid: req.params.userid, oldFileUrl, error: err });
+              }
+            }
+          })();
+        }
+
+        res.status(200).json({ result: "success", url: publicUrl, explicit });
+      })
+      .catch((err) => {
+        discardUpload(filename, { userid: req.params.userid, type: req.params.type });
+        logger.error("Profile update fetch error", err, { userid: req.params.userid });
+        res.status(500).json({
+          result: "failed",
+          message: "Error occured while uploading",
+          error: "Internal server error",
+        });
+      });
+  });
+});

--- a/views/editor.ejs
+++ b/views/editor.ejs
@@ -513,7 +513,7 @@
     <script src="https://cdn.socket.io/4.4.1/socket.io.min.js"></script>
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
-    <script src="/modules/socket.js?v=<%= ver %>"></script>
+    <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
     <script src="/js/editor.js?v=<%= ver %>"></script>
   </body>
 </html>

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -789,7 +789,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
-    <script src="/modules/socket.js?v=<%= ver %>"></script>
+    <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
     <script src="/js/game.js?v=<%= ver %>"></script>
   </body>
 </html>

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -149,7 +149,7 @@
     <script src="https://cdn.socket.io/4.4.1/socket.io.min.js"></script>
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
-    <script src="/modules/socket.js?v=<%= ver %>"></script>
+    <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
     <script src="/js/play.js?v=<%= ver %>"></script>
   </body>
 </html>

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -150,7 +150,7 @@
     <script src="https://cdn.socket.io/4.4.1/socket.io.min.js"></script>
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
-    <script src="/modules/socket.js?v=<%= ver %>"></script>
+    <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
     <script src="/js/test.js?v=<%= ver %>"></script>
   </body>
 </html>

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -146,7 +146,7 @@
     <script src="https://cdn.socket.io/4.4.1/socket.io.min.js"></script>
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
-    <script src="/modules/socket.js?v=<%= ver %>"></script>
+    <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
     <script src="/js/tutorial.js?v=<%= ver %>"></script>
   </body>
 </html>


### PR DESCRIPTION
## 요약

프로필/배경 이미지를 본 서버 디스크가 아니라 BunnyCDN 스토리지 존에 올린다. 겸사겸사 프로필 코드 분리, 주석 정리, `/game`에서 나던 스크립트 에러 수정까지 담았다.

## 커밋

| 커밋 | 내용 |
| --- | --- |
| `feat(profile)` | BunnyCDN 업로드 전환 + 프로필 코드를 `src/profile.ts`로 분리 |
| `chore(comments)` x2 | 서버/클라이언트 주석 영어 통일 및 정리 |
| `fix(game)` | `escapeHtml` 재선언 SyntaxError 수정 (socket.js 모듈 전환) |
| `feat(socket)` | `window.URLATE.socket` 노출 |

## BunnyCDN 전환

- multer를 `memoryStorage`로 바꿔 업로드 파일이 디스크에 닿지 않는다. sharp가 버퍼를 그대로 처리하고 결과만 저장소로 `PUT`.
- 저장 주소는 기존 Pull Zone 아래 `profiles/`. 응답 `url`과 백엔드에 넘기는 `value`가 모두 이 주소다.
- 이전 파일 삭제는 **우리가 올린 파일에만** 적용한다. 주소 접두사 + 파일명 규칙으로 판별해 Bunny면 Storage `DELETE`, 전환 전 업로드분이면 디스크에서 `unlink`. 기본 이미지·외부 아바타는 대상에서 빠진다.
- 업로드 후 백엔드 갱신이 실패하면 저장소에 남은 파일을 지운다. 저장소 업로드 자체가 실패하면 502.
- 설정이 비어 있으면 첫 업로드가 아니라 **부팅 시점**에 죽는다.

### 배포 전 필요한 것

`config/config.json`에 아래를 채워야 서버가 뜬다.

```json
"bunny": {
  "endpoint": "sg.storage.bunnycdn.com",
  "storageZone": "...",
  "accessKey": "...",
  "path": "profiles"
}
```

### 참고

`project.ignoredImageURL`은 이 경로에서 더 이상 쓰지 않는다. CDN 도메인 전체를 막고 있어 그대로 두면 새로 올린 파일이 영영 지워지지 않는다. 접두사 + 파일명 규칙이 더 좁은 판정이라 그쪽으로 대체했다. 설정 키는 남아 있으니 지울지는 따로 판단하면 된다.

## /game 스크립트 에러

`game.js`와 `socket.js`가 각각 최상위에 `let escapeHtml`을 선언했고, 두 파일을 함께 싣는 `/game`에서 클래식 스크립트가 하나의 전역 스코프를 공유해 재선언 SyntaxError가 났다. `socket.js`를 `type="module"`로 바꿔 자기 스코프를 갖게 했다. 밖에서 이 파일의 전역을 참조하는 코드가 없어 전환 영향이 없고, 앞으로 이름 충돌 자체가 불가능하다. 대신 클래식 쪽에서 쓸 수 있도록 `window.URLATE.socket`을 열어 뒀다.

## 확인한 것

- `tsc` 통과, 서버 부팅 후 `/info` 200, 인증 없는 `POST /profile/1/picture` 401
- 스토리지 존 자격증명으로 목록 조회(GET, 읽기 전용) 200 — 업로드/삭제는 실행하지 않음
- 모든 클라이언트 JS `node --check` 통과, eslint 통과
- `socket.js` + `game.js`를 이어 붙여 파싱하면 수정 전에는 재현되던 SyntaxError가 수정 후에는 나지 않음

브라우저가 없는 환경이라 실제 `/game` 화면 확인은 못 했다. 머지 전에 한 번 띄워보는 게 좋겠다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)