### PR TITLE
fix(server): 기본 리스닝 주소를 루프백으로 제한

### DIFF
--- a/config/config_example.json
+++ b/config/config_example.json
@@ -8,6 +8,7 @@
     "secretKey": "Something Random",
     "mode": "production",
     "port": 3000,
+    "host": "127.0.0.1",
     "trustProxy": 2,
     "sessionCookie": "urlate",
     "cookieDomain": "example.com"

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,9 +313,12 @@ process.on("uncaughtException", (error: Error) => {
   try {
     await initProfile();
 
-    app.listen(config.project.port, () => {
+    // 리버스 프록시가 앞에 있으므로 기본값은 루프백입니다. 와일드카드로 열면
+    // 포트가 방화벽 정책과 무관하게 외부에 그대로 노출됩니다.
+    const host = config.project.host ?? "127.0.0.1";
+    app.listen(config.project.port, host, () => {
       logger.info(`URLATE-v3l-frontend is running on version ${config.project.mode == "test" ? Date.now() : version}.`);
-      logger.success(`HTTP Server running at port ${config.project.port}.`);
+      logger.success(`HTTP Server running at ${host}:${config.project.port}.`);
     });
   } catch (err) {
     logger.fatal("Failed to initialize front-end server.", err);


### PR DESCRIPTION
## 배경

프런트엔드 서버가 `0.0.0.0`으로 바인딩되어 있어, 호스트 방화벽의 INPUT 정책과 무관하게 포트가 외부에 노출될 수 있는 상태였습니다. 실제 서버 점검 중 확인했습니다.

이 서버는 nginx 리버스 프록시 뒤에서만 접근하므로 와일드카드 바인딩이 필요하지 않습니다.

## 변경

- `app.listen()`에 바인딩 주소를 명시하고 기본값을 `127.0.0.1`로 지정
- `config.project.host`로 덮어쓸 수 있게 하여, 필요한 환경에서는 기존 동작 유지 가능
- `config_example.json`에 `host` 항목 추가
- 기동 로그를 `host:port` 형태로 변경

## 확인

- 배포 서버에서 적용 후 리스닝 주소가 `127.0.0.1:1025`로 전환된 것 확인
- nginx 경유 요청 정상 (HTTP 200)

동일한 변경을 `URLATE-v3l-backend`, `URLATE-v3l-game`에도 적용했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)