### PR TITLE
fix(join): 닉네임 pattern 정규식 v 플래그 오류 수정

### DIFF
--- a/views/join.ejs
+++ b/views/join.ejs
@@ -15,7 +15,7 @@
     <span id="title"><%= __('join') %></span>
     <span id="desc"><%= __('join_desc') %></span>
     <br />
-    <input type="text" name="displayName" placeholder="<%= __('namePlaceholder') %>" id="nickname" class="textbox" pattern="^[a-zA-Z0-9_-]*$" minlength="5" maxlength="12" required />
+    <input type="text" name="displayName" placeholder="<%= __('namePlaceholder') %>" id="nickname" class="textbox" pattern="^[a-zA-Z0-9_\-]*$" minlength="5" maxlength="12" required />
     <span id="nameExist"><%= __('nameExist') %></span>
     <span id="name"><%= __('nameText') %></span>
     <input type="submit" class="button" id="submit" value="<%= __('done') %>" />


### PR DESCRIPTION
## 문제

`/join` 진입 시 콘솔 에러 발생:

```
join:1 Pattern attribute value ^[a-zA-Z0-9_-]*$ is not a valid regular expression:
Uncaught SyntaxError: Invalid regular expression: /^[a-zA-Z0-9_-]*$/v: Invalid character in character class
```

패턴이 컴파일되지 않아 닉네임 입력의 클라이언트 측 형식 검증이 동작하지 않았다.

## 원인

브라우저는 `input` 요소의 `pattern` 속성을 `v` 플래그로 컴파일한다. `v` 모드에서는 문자 클래스 안의 리터럴 하이픈을 반드시 이스케이프해야 하며, 이스케이프되지 않은 `_-]`는 SyntaxError로 거부된다.

```js
new RegExp("^[a-zA-Z0-9_-]*$", "v")   // → Invalid character in character class
new RegExp("^[a-zA-Z0-9_\\-]*$", "v") // → ok
```

## 변경

`views/join.ejs`의 `pattern` 속성에서 하이픈을 이스케이프했다. 매칭되는 문자 집합은 이전과 동일하다.

`public/js/join.js`의 `nameReg`는 정규식 리터럴이라 `v` 플래그가 적용되지 않으므로 그대로 두었다. 다른 뷰에는 `pattern` 속성이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)