### PR TITLE
fix(build): 난독화가 Function() 생성자를 쓰지 않게 조정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
           cache: true
           install: true
 
+      # domain-lock / disable-console-output 은 빼두었습니다. 두 옵션만 Function()
+      # 생성자를 쓰는데, 계정 화면 CSP 에 unsafe-eval 이 없어 차단됩니다.
       - name: Core file obfuscate
         run: pnpm run obfuscate
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "supervisor dist/index.js",
     "start": "pm2 start ecosystem.config.js",
     "stop": "pm2 stop URLATE-v3l-frontend",
-    "obfuscate": "javascript-obfuscator public/js/ --output public/js/ --debug-protection false --disable-console-output true --domain-lock 'urlate.coupy.dev' --domain-lock-redirect-url 'urlate.coupy.dev' --numbers-to-expressions true --self-defending true"
+    "obfuscate": "javascript-obfuscator public/js/ --output public/js/ --debug-protection false --numbers-to-expressions true --self-defending true"
   },
   "author": "Coupyworks",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
프로덕션 `/`와 `/join`에서 페이지마다 CSP 위반이 2건씩 나고 있었습니다.

```
script-src <- eval | https://urlate.coupy.dev/js/index.js:1
script-src <- eval | https://urlate.coupy.dev/js/join.js:1
```

난독화 산출물이 전역 객체를 얻으려고 `Function()` 생성자를 쓰는데, 계정 화면 CSP에 `'unsafe-eval'`이 없어 차단됩니다. 해당 호출이 `try/catch`로 감싸여 `window` 폴백을 타기 때문에 동작은 이어졌지만, **막힌 쪽이 하필 domain-lock과 콘솔 차단이라 두 보호 장치가 사실상 무력화된 상태**였습니다.

## 어떤 옵션이 원인인지 측정했습니다

| 옵션 | `Function()` |
|---|---|
| `--disable-console-output true` | 1 |
| `--domain-lock` | 1 |
| `--self-defending true` | 0 |
| `--numbers-to-expressions true` | 0 |

현재 설정 전체를 돌리면 정확히 2건이 나와, 관측된 위반 수와 일치합니다.

## 변경

`--disable-console-output`과 `--domain-lock`(+`--domain-lock-redirect-url`)을 제거했습니다. `self-defending`과 `numbers-to-expressions`는 `Function()`을 만들지 않아 그대로 둡니다.

- **domain-lock**: 코드를 읽을 수 있는 상대에게는 손쉽게 제거되는 수준의 보호입니다. CSP를 약화시키면서까지 지킬 이유가 없다고 판단했습니다.
- **disable-console-output**: 최근 오류 처리 정리에서 진단용으로 남긴 `console.error`를 지우고 있었습니다. 걷어내는 편이 낫습니다.

## 검증

- `public/js` 8개 파일 전부 `Function()` **0건**
- 난독화 산출물을 실제 브라우저에 주입해 확인:
  - CSP 위반 **0건**, JS 오류 **0건**
  - `/join` 버튼 클릭 → `/auth/join` 호출 `{"displayName":"TestUser"}`
  - `/` 로그인 버튼 렌더 (197x44), GSI 객체 로드
  - `handleCredentialResponse` 전역 노출 유지 (GSI `data-callback`에 필요)

## 남는 선택지

domain-lock을 꼭 유지하고 싶으시면 되돌리는 대신 CSP에 `'unsafe-eval'`을 넣어야 하는데, 그러면 CSP의 XSS 방어 가치가 크게 떨어집니다. 권장하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)