### PR TITLE
feat(security): play·test·tutorial 화면에 CSP 적용

### DIFF
--- a/public/js/play.js
+++ b/public/js/play.js
@@ -1,4 +1,6 @@
 /* global Pace, Howler, Howl, url, cdn, api */
+// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
+// 통해 그 값들을 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
 let upperBound, lowerBound, numberWithCommas, easeOutSine, easeOutQuad;
 let Factory, Updater, Renderer;
 (async () => {

--- a/public/js/play.js
+++ b/public/js/play.js
@@ -913,7 +913,7 @@ const resume = () => {
   floatingResumeContainer.style.opacity = 1;
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const retry = () => {
   if (isResultShowing) {
     if (localStorage.record < score) localStorage.record = score;
@@ -980,12 +980,12 @@ const retry = () => {
   }, 100);
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const home = () => {
   window.location.href = `${url}/game?initialize=1`;
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const settingChanged = (e, v) => {
   if (v == "volumeMaster") {
     settings.sound.volume.master = e.value / 100;
@@ -1185,3 +1185,17 @@ document.getElementById("componentCanvas").addEventListener("mousedown", (event)
 document.getElementById("componentCanvas").addEventListener("mouseup", (event) => {
   checkHoldNote(`${event.button}mouse`);
 });
+
+// CSP를 걸기 위해 마크업의 on* 속성에서 옮겨온 것들입니다.
+document.addEventListener("contextmenu", (event) => event.preventDefault());
+document.addEventListener("dragstart", (event) => event.preventDefault());
+document.addEventListener("selectstart", (event) => event.preventDefault());
+
+document.querySelector(".volumeMaster").addEventListener("input", (event) => {
+  settingChanged(event.target, "volumeMaster");
+});
+document.getElementById("retryButton").addEventListener("click", retry);
+document.getElementById("nextButton").addEventListener("click", home);
+document.getElementById("resume").addEventListener("click", resume);
+document.getElementById("retry").addEventListener("click", retry);
+document.getElementById("backToHome").addEventListener("click", home);

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -824,7 +824,7 @@ const resume = () => {
   floatingResumeContainer.style.opacity = 1;
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const retry = () => {
   if (isResultShowing) return location.reload();
   blackOverlayContainer.classList.add("show");
@@ -885,17 +885,17 @@ const retry = () => {
   }, 100);
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const editor = () => {
   window.location.href = `${url}/editor${background == "0" ? "?background=0" : ""}`;
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const home = () => {
   window.location.href = `${url}/game?initialize=0`;
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const settingChanged = (e, v) => {
   if (v == "volumeMaster") {
     settings.sound.volume.master = e.value / 100;
@@ -1093,3 +1093,18 @@ document.getElementById("componentCanvas").addEventListener("mousedown", (event)
 document.getElementById("componentCanvas").addEventListener("mouseup", (event) => {
   checkHoldNote(`${event.button}mouse`);
 });
+
+// CSP를 걸기 위해 마크업의 on* 속성에서 옮겨온 것들입니다.
+document.addEventListener("contextmenu", (event) => event.preventDefault());
+document.addEventListener("dragstart", (event) => event.preventDefault());
+document.addEventListener("selectstart", (event) => event.preventDefault());
+
+document.querySelector(".volumeMaster").addEventListener("input", (event) => {
+  settingChanged(event.target, "volumeMaster");
+});
+document.getElementById("retryButton").addEventListener("click", retry);
+document.getElementById("nextButton").addEventListener("click", editor);
+document.getElementById("resume").addEventListener("click", resume);
+document.getElementById("retry").addEventListener("click", retry);
+document.getElementById("backToEditor").addEventListener("click", editor);
+document.getElementById("backToHome").addEventListener("click", home);

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -1,4 +1,6 @@
 /* global Pace, Howler, Howl, url, cdn, api */
+// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
+// 통해 그 값들을 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
 let upperBound, lowerBound, numberWithCommas, easeOutSine;
 let Factory, Updater, Renderer;
 (async () => {

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -813,7 +813,7 @@ const resume = () => {
   floatingResumeContainer.style.opacity = 1;
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const retry = () => {
   if (isResultShowing) return location.reload();
   blackOverlayContainer.classList.add("show");
@@ -874,7 +874,7 @@ const retry = () => {
   }, 100);
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const home = () => {
   if (confirm(confirmExit)) {
     fetch(`${api}/tutorial`, {
@@ -896,7 +896,7 @@ const home = () => {
   }
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const settingChanged = (e, v) => {
   if (v == "volumeMaster") {
     settings.sound.volume.master = e.value / 100;
@@ -918,7 +918,7 @@ const overlayClose = (s) => {
   }
 };
 
-// eslint-disable-next-line no-unused-vars
+ 
 const finish = () => {
   window.location.href = `${url}/game?initialize=0`;
 };
@@ -1099,3 +1099,17 @@ document.getElementById("componentCanvas").addEventListener("mousedown", (event)
 document.getElementById("componentCanvas").addEventListener("mouseup", (event) => {
   checkHoldNote(`${event.button}mouse`);
 });
+
+// CSP를 걸기 위해 마크업의 on* 속성에서 옮겨온 것들입니다.
+document.addEventListener("contextmenu", (event) => event.preventDefault());
+document.addEventListener("dragstart", (event) => event.preventDefault());
+document.addEventListener("selectstart", (event) => event.preventDefault());
+
+document.querySelector(".volumeMaster").addEventListener("input", (event) => {
+  settingChanged(event.target, "volumeMaster");
+});
+document.getElementById("retryButton").addEventListener("click", retry);
+document.getElementById("nextButton").addEventListener("click", finish);
+document.getElementById("resume").addEventListener("click", resume);
+document.getElementById("retry").addEventListener("click", retry);
+document.getElementById("backToHome").addEventListener("click", home);

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -1,4 +1,6 @@
 /* global Pace, Howler, Howl, url, cdn, api, lang, confirmExit */
+// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
+// 통해 그 값들을 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
 let upperBound, lowerBound, numberWithCommas, easeOutSine;
 let Factory, Updater, Renderer;
 (async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,9 +49,9 @@ app.set("view engine", "ejs");
 app.set("views", __dirname + "/../views");
 app.use(cookieParser());
 
-// Baseline security headers. CSP is applied per-route on the account pages only;
-// the rest still carry inline handlers (editor 136, game 97) that a global policy
-// would break.
+// Baseline security headers. CSP is applied per-route: the account pages and the
+// three play screens carry it, while editor (136 inline handlers) and game (97)
+// still need the markup cleaned up before a policy can hold there.
 app.use((req, res, next) => {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "SAMEORIGIN");
@@ -111,11 +111,60 @@ const authPageCsp = (nonce: string, withGsi: boolean) => {
   ].join("; ");
 };
 
+const SOCKET_IO_ORIGIN = "https://cdn.socket.io";
+
+/**
+ * 플레이 화면(play·test·tutorial)용 정책입니다. 계정 화면과 쓰는 출처가 거의
+ * 겹치지 않아 정책을 합치면 양쪽 모두에게 필요 없는 권한을 열어주게 됩니다.
+ *
+ * 세 화면은 마크업과 스크립트 구조가 같아 정책 하나를 공유합니다.
+ */
+const playPageCsp = (nonce: string) => {
+  // socket.io는 폴링(https)으로 붙었다가 웹소켓으로 승격하므로 두 스킴이 다
+  // 필요합니다. 하나만 열어두면 승격 단계나 최초 연결 중 하나가 막힙니다.
+  const gameSocket = config.project.game.replace(/^https:/, "wss:");
+
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' ${SOCKET_IO_ORIGIN}`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+    "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net",
+    // 앨범아트와 배경이 CDN에서 옵니다.
+    `img-src 'self' data: ${config.project.cdn}`,
+    // Howler는 기본적으로 Web Audio로 받아 connect-src를 타지만, 브라우저가
+    // 지원하지 않으면 <audio>로 떨어져 media-src를 탑니다. 어느 쪽으로 가든
+    // 곡이 재생되도록 둘 다 열어둡니다.
+    `media-src 'self' ${config.project.cdn}`,
+    // 패턴·스킨 JSON과 곡 파일(CDN), 기록·설정 API, 게임 서버 소켓입니다.
+    // jsdelivr는 개발자 도구를 열었을 때 폰트 CSS의 소스맵을 받아옵니다.
+    `connect-src 'self' ${config.project.api} ${config.project.cdn} ${config.project.game} ${gameSocket} https://cdn.jsdelivr.net`,
+    "frame-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'",
+    "object-src 'none'",
+  ].join("; ");
+};
+
 // 요청마다 새로 만듭니다. 재사용하면 공격자가 값을 알아내 인라인 스크립트를
 // 통과시킬 수 있어 nonce의 의미가 사라집니다.
 const withAuthPageCsp = (res: Response, withGsi: boolean): string => {
   const nonce = randomBytes(16).toString("base64");
   res.setHeader("Content-Security-Policy", authPageCsp(nonce, withGsi));
+  return nonce;
+};
+
+/**
+ * 계정 화면과 달리 Report-Only로 시작합니다. 세 화면은 로그인 세션이 있어야
+ * 열려서 브라우저로 위반을 직접 수집하지 못했고, 정책은 코드에서 쓰이는 출처를
+ * 훑어 세운 것입니다. 곧바로 강제하면 빠뜨린 출처 하나에 곡이 안 받아지거나
+ * 소켓이 끊겨 게임이 멈춥니다.
+ *
+ * 실제 플레이에서 콘솔에 위반이 남지 않는 것을 확인한 뒤 강제로 바꿔야 합니다.
+ */
+const withPlayPageCsp = (res: Response): string => {
+  const nonce = randomBytes(16).toString("base64");
+  res.setHeader("Content-Security-Policy-Report-Only", playPageCsp(nonce));
   return nonce;
 };
 
@@ -356,6 +405,7 @@ app.get("/test", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
+    cspNonce: withPlayPageCsp(res),
     ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
@@ -366,6 +416,7 @@ app.get("/play", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
+    cspNonce: withPlayPageCsp(res),
     ver: config.project.mode == "test" ? Date.now() : version,
   });
 });
@@ -376,6 +427,7 @@ app.get("/tutorial", gateLimiter, requireAuth, async (req, res) => {
     url: config.project.url,
     api: config.project.api,
     game: config.project.game,
+    cspNonce: withPlayPageCsp(res),
     ver: config.project.mode == "test" ? Date.now() : version,
   });
 });

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -150,6 +150,6 @@
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
     <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
-    <script src="/js/play.js?v=<%= ver %>"></script>
+    <script type="module" src="/js/play.js?v=<%= ver %>"></script>
   </body>
 </html>

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -15,7 +15,7 @@
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <script data-pace-options='{ "eventLag": false }' src="/js/pace.js"></script>
   </head>
-  <body oncontextmenu="return false" ondragstart="return false" onselect="return false">
+  <body>
     <div id="colorOverlayContainer"></div>
     <div id="blackOverlayContainer"></div>
     <div id="scoreContainer">
@@ -74,10 +74,10 @@
       </div>
       <span id="urlate"><strong>URLATE</strong> LITE</span>
       <div id="skip">
-        <div id="retryButton" onclick="retry()">
+        <div id="retryButton">
           <img src="/icons/retry.svg" id="retryIcon" />
         </div>
-        <div id="nextButton" onclick="home()">
+        <div id="nextButton">
           <span>Next</span>
           <img src="/icons/next.svg" id="nextIcon" />
         </div>
@@ -86,9 +86,9 @@
     <div id="menuContainer">
       <span id="menuTitle">Paused</span>
       <div id="menuBox">
-        <div id="resume" class="menuBtn" onclick="resume()"><span>Resume</span></div>
-        <div id="retry" class="menuBtn" onclick="retry()"><span>Retry</span></div>
-        <div id="backToHome" class="menuBtn" onclick="home()"><span>Back to home</span></div>
+        <div id="resume" class="menuBtn"><span>Resume</span></div>
+        <div id="retry" class="menuBtn"><span>Retry</span></div>
+        <div id="backToHome" class="menuBtn"><span>Back to home</span></div>
       </div>
       <span id="menuVolume"><%= __('menu_volume') %></span>
     </div>
@@ -124,10 +124,10 @@
     </div>
     <div class="overlay" id="volumeOverlay">
       <p class="optionSemiTitle"><%= __('volume') %></p>
-      <input type="range" min="0" max="100" value="50" class="optionSlider volumeMaster" oninput="settingChanged(this, 'volumeMaster')" />
+      <input type="range" min="0" max="100" value="50" class="optionSlider volumeMaster" />
       <p class="optionValue" id="volumeMasterValue">50%</p>
     </div>
-    <script>
+    <script nonce="<%= cspNonce %>">
       const cdn = "<%= cdn %>";
       const url = "<%= url %>";
       const api = "<%= api %>";

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -151,6 +151,6 @@
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
     <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
-    <script src="/js/test.js?v=<%= ver %>"></script>
+    <script type="module" src="/js/test.js?v=<%= ver %>"></script>
   </body>
 </html>

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -15,7 +15,7 @@
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <script data-pace-options='{ "eventLag": false }' src="/js/pace.js"></script>
   </head>
-  <body oncontextmenu="return false" ondragstart="return false" onselect="return false">
+  <body>
     <div id="colorOverlayContainer"></div>
     <div id="blackOverlayContainer"></div>
     <div id="scoreContainer">
@@ -74,10 +74,10 @@
       </div>
       <span id="urlate"><strong>URLATE</strong> LITE</span>
       <div id="skip">
-        <div id="retryButton" onclick="retry()">
+        <div id="retryButton">
           <img src="/icons/retry.svg" id="retryIcon" />
         </div>
-        <div id="nextButton" onclick="editor()">
+        <div id="nextButton">
           <span>Next</span>
           <img src="/icons/next.svg" id="nextIcon" />
         </div>
@@ -86,10 +86,10 @@
     <div id="menuContainer">
       <span id="menuTitle">Paused</span>
       <div id="menuBox">
-        <div id="resume" class="menuBtn" onclick="resume()"><span>Resume</span></div>
-        <div id="retry" class="menuBtn" onclick="retry()"><span>Retry</span></div>
-        <div id="backToEditor" class="menuBtn" onclick="editor()"><span>Back to editor</span></div>
-        <div id="backToHome" class="menuBtn" onclick="home()"><span>Back to home</span></div>
+        <div id="resume" class="menuBtn"><span>Resume</span></div>
+        <div id="retry" class="menuBtn"><span>Retry</span></div>
+        <div id="backToEditor" class="menuBtn"><span>Back to editor</span></div>
+        <div id="backToHome" class="menuBtn"><span>Back to home</span></div>
       </div>
       <span id="menuVolume"><%= __('menu_volume') %></span>
     </div>
@@ -125,10 +125,10 @@
     </div>
     <div class="overlay" id="volumeOverlay">
       <p class="optionSemiTitle"><%= __('volume') %></p>
-      <input type="range" min="0" max="100" value="50" class="optionSlider volumeMaster" oninput="settingChanged(this, 'volumeMaster')" />
+      <input type="range" min="0" max="100" value="50" class="optionSlider volumeMaster" />
       <p class="optionValue" id="volumeMasterValue">50%</p>
     </div>
-    <script>
+    <script nonce="<%= cspNonce %>">
       const cdn = "<%= cdn %>";
       const url = "<%= url %>";
       const api = "<%= api %>";

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -15,7 +15,7 @@
     <link rel="shortcut icon" href="/images/favicon.ico" />
     <script data-pace-options='{ "eventLag": false }' src="/js/pace.js"></script>
   </head>
-  <body oncontextmenu="return false" ondragstart="return false" onselect="return false">
+  <body>
     <div id="colorOverlayContainer"></div>
     <div id="blackOverlayContainer"></div>
     <div id="scoreContainer">
@@ -74,10 +74,10 @@
       </div>
       <span id="urlate"><strong>URLATE</strong> LITE</span>
       <div id="skip">
-        <div id="retryButton" onclick="retry()">
+        <div id="retryButton">
           <img src="/icons/retry.svg" id="retryIcon" />
         </div>
-        <div id="nextButton" onclick="finish()">
+        <div id="nextButton">
           <span>Next</span>
           <img src="/icons/next.svg" id="nextIcon" />
         </div>
@@ -86,9 +86,9 @@
     <div id="menuContainer">
       <span id="menuTitle">Paused</span>
       <div id="menuBox">
-        <div id="resume" class="menuBtn" onclick="resume()"><span>Resume</span></div>
-        <div id="retry" class="menuBtn" onclick="retry()"><span>Retry</span></div>
-        <div id="backToHome" class="menuBtn" onclick="home()"><span>Back to home</span></div>
+        <div id="resume" class="menuBtn"><span>Resume</span></div>
+        <div id="retry" class="menuBtn"><span>Retry</span></div>
+        <div id="backToHome" class="menuBtn"><span>Back to home</span></div>
       </div>
       <span id="menuVolume"><%= __('menu_volume') %></span>
     </div>
@@ -120,10 +120,10 @@
     </div>
     <div class="overlay" id="volumeOverlay">
       <p class="optionSemiTitle"><%= __('volume') %></p>
-      <input type="range" min="0" max="100" value="50" class="optionSlider volumeMaster" oninput="settingChanged(this, 'volumeMaster')" />
+      <input type="range" min="0" max="100" value="50" class="optionSlider volumeMaster" />
       <p class="optionValue" id="volumeMasterValue">50%</p>
     </div>
-    <script>
+    <script nonce="<%= cspNonce %>">
       const cdn = "<%= cdn %>";
       const url = "<%= url %>";
       const api = "<%= api %>";

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -147,6 +147,6 @@
     <script src="/lib/howler.min.js"></script>
     <script src="/lib/iziToast.min.js"></script>
     <script type="module" src="/modules/socket.js?v=<%= ver %>"></script>
-    <script src="/js/tutorial.js?v=<%= ver %>"></script>
+    <script type="module" src="/js/tutorial.js?v=<%= ver %>"></script>
   </body>
 </html>


### PR DESCRIPTION
계정 화면(#328)에 이어 세 플레이 화면으로 CSP를 넓혔습니다.

## 왜 이 세 화면부터인가

인라인 이벤트 핸들러 분포가 극단적입니다.

| 화면 | 인라인 핸들러 |
|---|---|
| editor | 136 |
| game | 97 |
| **play / test / tutorial** | **9 / 10 / 9** |
| index / join | 1 / 1 (#328에서 처리) |

정리 비용이 작은 쪽부터 덮었습니다. `editor`와 `game`은 별도 작업이 필요합니다.

## 마크업 정리

`body`의 `oncontextmenu`·`ondragstart`·`onselect`, 버튼 `onclick`(retry/home/resume/editor/finish), 볼륨 슬라이더 `oninput`을 전부 스크립트로 옮겼습니다. **세 화면 모두 인라인 핸들러 0개**가 됐습니다.

전역 변수를 심는 인라인 `<script>`에는 요청마다 새로 만든 nonce를 붙입니다.

## 정책

코드에서 실제로 쓰이는 출처를 훑어 세웠습니다.

```
default-src 'self'
script-src  'self' 'nonce-…' https://cdn.socket.io
style-src   'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net
font-src    'self' fonts.gstatic.com cdn.jsdelivr.net
img-src     'self' data: <cdn>
media-src   'self' <cdn>
connect-src 'self' <api> <cdn> <game> wss://<game> cdn.jsdelivr.net
frame-src 'none' / base-uri 'self' / form-action 'self' / object-src 'none'
```

- **곡 재생**: Howler는 기본적으로 Web Audio로 받아 `connect-src`를 타지만, 브라우저가 지원하지 않으면 `<audio>`로 떨어져 `media-src`를 탑니다. 어느 경로로 가든 막히지 않도록 둘 다 열었습니다.
- **소켓**: socket.io는 폴링(https)으로 붙었다가 웹소켓으로 승격하므로 `https`와 `wss`를 함께 넣었습니다. 하나만 열면 최초 연결이나 승격 중 하나가 막힙니다.
- 출처는 전부 `config.project.*`에서 가져오므로 dev/프로덕션이 각자 값을 씁니다.

## ⚠️ Report-Only로 시작합니다

세 화면은 **로그인 세션이 있어야 열려서** 브라우저로 위반을 직접 수집하지 못했습니다. 인증이 서버 대 서버 호출이라 브라우저에서 우회할 수 없습니다.

곧바로 강제하면 빠뜨린 출처 하나에 곡이 안 받아지거나 소켓이 끊겨 게임이 멈춥니다. 그래서 정책은 코드 조사로 세우고 Report-Only로 내보냅니다.

**배포 후 실제로 한 곡 플레이해보시고** 콘솔에 `[Report Only]` 위반이 없으면, `src/index.ts`의 `withPlayPageCsp`에서 헤더 이름을 `Content-Security-Policy`로 바꿔주세요.

## 검증

- `pnpm run build`, eslint 통과
- 템플릿 3개 렌더 결과: nonce 적용 1개씩, **nonce 없는 인라인 script 0**, **인라인 핸들러 0**
- 생성되는 정책 문자열이 설정값을 따라가는 것 확인 (`wss://` 승격 포함)
- 인라인에서만 불리던 함수들을 스크립트에서 참조하게 되면서 불필요해진 `eslint-disable` 11개도 함께 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)