### PR TITLE
refactor(play): 키보드 핸들러를 addEventListener 로 변경

### DIFF
--- a/public/js/play.js
+++ b/public/js/play.js
@@ -1117,7 +1117,7 @@ const checkHoldNote = (key) => {
   }
 };
 
-document.onkeydown = (e) => {
+document.addEventListener("keydown", (e) => {
   e = e || window.event;
   if (e.repeat) return;
   if (pressingKeys.includes(e.key)) return;
@@ -1149,9 +1149,9 @@ document.onkeydown = (e) => {
     pressingKeys.push(e.key);
     compClicked(true, e.key, false);
   }
-};
+});
 
-document.onkeyup = (e) => {
+document.addEventListener("keyup", (e) => {
   e = e || window.event;
   if (e.key == "Escape") {
     return;
@@ -1159,7 +1159,7 @@ document.onkeyup = (e) => {
     shiftDown = false;
   }
   checkHoldNote(e.key);
-};
+});
 
 window.addEventListener("resize", () => {
   initialize(false);

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -1025,7 +1025,7 @@ const checkHoldNote = (key) => {
   }
 };
 
-document.onkeydown = (e) => {
+document.addEventListener("keydown", (e) => {
   e = e || window.event;
   if (e.repeat) return;
   if (pressingKeys.includes(e.key)) return;
@@ -1057,9 +1057,9 @@ document.onkeydown = (e) => {
     pressingKeys.push(e.key);
     compClicked(true, e.key, false);
   }
-};
+});
 
-document.onkeyup = (e) => {
+document.addEventListener("keyup", (e) => {
   e = e || window.event;
   if (e.key == "Escape") {
     return;
@@ -1067,7 +1067,7 @@ document.onkeyup = (e) => {
     shiftDown = false;
   }
   checkHoldNote(e.key);
-};
+});
 
 window.addEventListener("resize", () => {
   initialize(false);

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -1031,7 +1031,7 @@ const checkHoldNote = (key) => {
   }
 };
 
-document.onkeydown = (e) => {
+document.addEventListener("keydown", (e) => {
   e = e || window.event;
   if (e.repeat) return;
   if (pressingKeys.includes(e.key)) return;
@@ -1063,9 +1063,9 @@ document.onkeydown = (e) => {
     pressingKeys.push(e.key);
     compClicked(true, e.key, false);
   }
-};
+});
 
-document.onkeyup = (e) => {
+document.addEventListener("keyup", (e) => {
   e = e || window.event;
   if (e.key == "Escape") {
     return;
@@ -1073,7 +1073,7 @@ document.onkeyup = (e) => {
     shiftDown = false;
   }
   checkHoldNote(e.key);
-};
+});
 
 window.addEventListener("resize", () => {
   initialize(false);


### PR DESCRIPTION
#333 작업 중 발견한 것을 별도 PR로 정리합니다. `play`·`test`·`tutorial`의 `document.onkeydown`/`onkeyup` 6곳입니다.

## 왜

`.on* =` 대입은 나중에 같은 이벤트에 리스너를 하나 더 달면 **앞의 것을 조용히 덮습니다.** CSP에 걸리는 문제는 아니지만, 이번에 인라인 핸들러를 걷어내면서 같은 계열의 패턴을 함께 정리합니다.

## 바꾸기 전에 확인한 것

`.on* =`는 덮어쓰고 `addEventListener`는 **쌓입니다.** 여러 번 실행되는 자리에서 바꾸면 리스너가 중복돼 키 입력이 두 번씩 처리됩니다. 그래서 먼저 확인했습니다.

| 확인 | 결과 |
|---|---|
| 대입 횟수 | 파일당 `keydown` 1회, `keyup` 1회 |
| 실행 위치 | 모듈 최상위 (들여쓰기 0) — 한 번만 실행 |
| `= null` 로 해제하는 코드 | 없음 |
| 핸들러를 읽어 보관하는 코드 | 없음 |
| `removeEventListener` 사용 | 없음 |

교체 의미에 기대는 코드가 없어 `addEventListener`로 바꿔도 동작이 달라지지 않습니다.

## 검증

브라우저에서 변환 전후로 같은 키를 눌러 비교했습니다.

```
before:  z 키 호출 1회  [["checkHoldNote","z"]]
after:   z 키 호출 1회  [["checkHoldNote","z"]]
```

**중복 누적이 없습니다.** 블록을 떼어낸 harness라 양쪽 모두 `globalScrollEvent is not defined`가 나오지만 동일한 환경 문제입니다.

`node --check` 구문 검증, `pnpm run build`, eslint 모두 통과했습니다.

## 관련

- #333 (game) 에서 같은 계열 패턴을 정리 중입니다. `editor.js`는 아직 남아 있습니다 — `reader.onload`, `window.onload`, `document.body.onmousedown`/`onmouseup`, `document.onkeydown`/`onkeyup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)