### PR TITLE
chore: clean up comments repo-wide

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,6 @@ jobs:
           cache: true
           install: true
 
-      # domain-lock / disable-console-output 은 빼두었습니다. 두 옵션만 Function()
-      # 생성자를 쓰는데, 계정 화면 CSP 에 unsafe-eval 이 없어 차단됩니다.
       - name: Core file obfuscate
         run: pnpm run obfuscate
 

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -262,8 +262,6 @@ body {
   left: 0;
   position: absolute;
   z-index: 2;
-  /*overflow-y: scroll;
-  overflow-x: scroll;*/
   background-color: #fff;
   width: 100vw;
   height: 27vh;
@@ -418,7 +416,6 @@ body {
 #initialScreenContainer {
   width: 100vw;
   height: 100vh;
-  /*display: none;*/
 }
 
 #initialButtonsContainer {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -125,8 +125,8 @@ body {
   pointer-events: none;
 }
 
-/* GSI 스크립트가 차단됐을 때만 드러납니다. 로그인만 막힌 상황이므로 화면
-   전체를 가리지 않고 버튼 자리 옆에 안내만 둡니다. */
+/* Only shown when the GSI script is blocked. Since only login is affected, this
+   sits next to the button instead of covering the whole screen. */
 #loginNotice {
   z-index: 1;
   margin: 1vh;

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -1,6 +1,6 @@
 /* global Howler, Howl, iziToast, url, api, cdn, syncAlert, timeAlert, copiedText, moveToAlert */
-// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
-// 통해 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
+// url/cdn/api etc. are set by the page's inline <script> and by the classic
+// library scripts; a module can read them via global scope with no extra wiring.
 let upperBound, lowerBound;
 let Factory, Updater, Renderer, getCos, getSin, calcAngleDegrees;
 (async () => {
@@ -271,7 +271,7 @@ const analyzePattern = (data) => {
 
   return {
     speed: data.information.speed,
-    noteDensity: calculateDensity(notePerBeat, 0.25, 1.5), // 4박자당 1개 = 0.25, 2박자당 3개 = 1.5
+    noteDensity: calculateDensity(notePerBeat, 0.25, 1.5), // 1 per 4 beats = 0.25, 3 per 2 beats = 1.5
     bulletDensity: calculateLogDensity(bulletPerBeat, 20, 100),
   };
 };
@@ -1719,8 +1719,6 @@ const changeOffset = (e) => {
 };
 
  
-// 예전에는 전역 event(window.event)를 읽었습니다. 위임이 이벤트를 넘겨주므로
-// 인자로 받습니다. 값은 같고, 사라져가는 전역에 기대지 않게 됩니다.
 const trackMousePos = (event) => {
   const width = parseInt((componentViewOW - canvasContainerOW) / 2 + menuContainerOW);
   const x = ((event.clientX - width) / canvasContainerOW) * 200 - 100;
@@ -1735,7 +1733,6 @@ const trackMousePos = (event) => {
 };
 
  
-// trackMousePos 와 같은 이유로 인자를 받습니다.
 const trackTimelineMousePos = (event) => {
   mouseMode = 1;
   mouseX = event.clientX * pixelRatio;
@@ -2918,10 +2915,7 @@ window.addEventListener("load", () => {
   }
 });
 
-// 아래는 마크업의 on* 속성에서 옮겨온 결선입니다. CSP 를 걸려면 인라인 핸들러가
-// 없어야 하는데 이 화면에만 138개가 있어, 요소마다 리스너를 다는 대신 data-*
-// 속성과 위임으로 처리합니다.
-
+// Delegated click handlers, keyed by each element's data-action attribute.
 const clickActions = {
   changeMode: (arg) => changeMode(Number(arg)),
   changeNote,
@@ -2932,7 +2926,7 @@ const clickActions = {
   elementPaste,
   goGame: () => (window.location.href = `${url}/game?initialize=0`),
   gotoMain,
-  // 저장하지 않고 나가기 전에 한 번 더 묻는 쪽입니다.
+  // Confirms before leaving unsaved work.
   gotoMainConfirm: () => gotoMain(true),
   loadEditor,
   moveTo,
@@ -2960,8 +2954,7 @@ document.addEventListener("click", (event) => {
   if (action) action(target.dataset.arg);
 });
 
-// 입력값을 패턴에 반영하는 것들입니다. 키를 함께 받는 쪽과 요소만 받는 쪽이
-// 있어 인자 유무로 갈립니다.
+// Some of these take a key argument along with the element, others just the element.
 const inputActions = { settingsInput, triggersInput, changeBPM, changeOffset, changeSpeed };
 const runInputAction = (target) => {
   const action = inputActions[target.dataset.keyup];
@@ -2974,17 +2967,15 @@ document.addEventListener("keyup", (event) => {
   if (target) runInputAction(target);
 });
 
-// focus·blur 는 버블링하지 않아 위임이 닿지 않습니다. 버블링하는 짝인
-// focusin·focusout 을 씁니다.
+// focus/blur don't bubble, so delegation can't catch them; use the bubbling
+// equivalents, focusin/focusout, instead.
 document.addEventListener("focusin", (event) => {
   if (event.target.closest?.(".settingsPropertiesTextbox")) textFocused();
 });
 document.addEventListener("focusout", (event) => {
   const target = event.target.closest?.(".settingsPropertiesTextbox");
   if (!target) return;
-  // 입력 중에 반영하면 어중간한 값이 들어가는 항목들은 포커스를 잃을 때 반영합니다.
-  // triggersInput 이 해당 키에서 textBlurred 를 직접 부르므로 여기서 또 부르지
-  // 않습니다. 원래 마크업도 이 요소들에는 textBlurred 를 걸지 않았습니다.
+  // triggersInput already calls textBlurred for these keys, so it isn't called again here.
   if (target.dataset.blur === "triggersInput") {
     triggersInput(target.dataset.blurArg, target);
     return;
@@ -3016,7 +3007,6 @@ const delegateMouse = (type, attribute) => {
 };
 delegateMouse("mousemove", "mousemove");
 delegateMouse("mousedown", "mousedown");
-// mouseover·mouseout 은 버블링하므로 위임이 그대로 닿습니다.
 delegateMouse("mouseover", "mouseover");
 delegateMouse("mouseout", "mouseout");
 

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1,6 +1,6 @@
 /* global Howler, Howl, Pace, Chart, iziToast, url, cdn, api, lang, confirmExit, pressAnywhere, notAvailable1, notAvailable2, medalDesc, alias, nothingHere, rating, couponApplySuccess, couponInvalid1, couponInvalid2, couponUsed, inputEmpty, aliasSelect, pictureMessage, imageError */
-// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
-// 통해 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
+// url/cdn/api etc. are set by the page's inline <script> and by the classic
+// library scripts; a module can read them via global scope with no extra wiring.
 const langDetailSelector = document.getElementById("langDetailSelector");
 const canvasResSelector = document.getElementById("canvasResSelector");
 const albumResSelector = document.getElementById("albumResSelector");
@@ -49,8 +49,6 @@ const profileNameContainer = document.getElementById("profileNameContainer");
 const slowRate = 110 / 174;
 const fastRate = 174 / 110;
 
-// 모듈이 된 뒤로는 정적 import 로 받습니다. 동적 import 는 해석되기 전까지
-// 두 함수가 undefined 라, 그 사이에 랭킹이나 프로필이 그려지면 터졌습니다.
 import { escapeHtml, safeUrl } from "../modules/utils.js";
 
 let settings = [];
@@ -308,7 +306,6 @@ const tutorialSkip = () => {
         }
       })
       .catch((error) => {
-        // alert(`Error occured.\n${error}`);
         console.error(`Error occured.\n${error}`);
         location.reload();
       });
@@ -335,8 +332,7 @@ const checkIntroReady = () => {
   if (introReady.done || !(introReady.video1 && introReady.video2 && introReady.minDelay)) return;
   introReady.done = true;
   document.getElementById("pressAnywhere").textContent = pressAnywhere;
-  // 마크업에 미리 박아두면 인트로 준비 전에도 눌립니다. 준비가 끝난 시점에
-  // 속성을 달아 기존 조건을 그대로 지킵니다.
+  // Set only once ready, rather than in markup, so clicks before that do nothing.
   warningContainer.dataset.action = "warningSkip";
 };
 
@@ -1159,8 +1155,8 @@ const rankUpdate = async () => {
   }
 };
 
-// Profiles are looked up by nickname: the ranking no longer carries userid, and
-// nothing on this screen needs the internal identifier.
+// Profiles are looked up by nickname: the ranking payload carries no userid,
+// and nothing on this screen needs the internal identifier.
 const profileUpdate = async (nickname, isMe) => {
   profileid = nickname;
   const res = await fetch(`${api}/profile/nickname/${encodeURIComponent(nickname)}`, {
@@ -2224,16 +2220,14 @@ window.onpopstate = () => {
   }
 };
 
-// 아래는 마크업의 on* 속성에서 옮겨온 결선입니다. CSP 를 걸려면 인라인 핸들러가
-// 없어야 하는데, 이 화면은 97개나 있어 요소마다 리스너를 다는 대신 data-* 속성과
-// 위임으로 처리합니다. 새 버튼을 추가할 때도 속성만 붙이면 됩니다.
+// Delegated click handlers, keyed by each element's data-action attribute.
 
-// 인자 없이 부르는 동작입니다.
+// Actions invoked without an argument.
 const clickActions = {
   couponEnter,
   changeProfile: (arg) => changeProfile(arg),
-  // 아래 둘은 마크업이 아니라 innerHTML 로 만들어지는 요소에 붙습니다.
-  // 위임이라 나중에 끼워 넣어져도 그대로 걸립니다.
+  // These attach to elements created via innerHTML rather than markup;
+  // delegation still catches them once inserted.
   bannerToggle: (arg) => bannerToggle(Number(arg)),
   difficultySelected: (arg) => difficultySelected(Number(arg)),
   displayClose,
@@ -2244,7 +2238,7 @@ const clickActions = {
   logout,
   medalDescription,
   menuSelected: (arg) => menuSelected(Number(arg)),
-  // 설명 문구가 클릭을 삼키던 자리입니다. 아무 일도 하지 않는 게 목적입니다.
+  // Swallows clicks on the description text; intentionally a no-op.
   noop: () => {},
   offsetDown,
   offsetReset,
@@ -2269,8 +2263,8 @@ const clickActions = {
   warningSkip,
 };
 
-// 숫자 인자는 Number 로 바꿔 넘깁니다. data-* 값은 항상 문자열이라, 그대로
-// 넘기면 sortSelected("0") 처럼 타입이 달라집니다.
+// data-arg is always a string, so numeric actions convert it with Number();
+// otherwise e.g. sortSelected would receive "0" instead of 0.
 document.addEventListener("click", (event) => {
   const target = event.target.closest("[data-action]");
   if (!target) return;
@@ -2278,8 +2272,7 @@ document.addEventListener("click", (event) => {
   if (action) action(target.dataset.arg, event);
 });
 
-// 값이 바뀔 때 설정을 저장하는 컨트롤입니다. range 는 input, select·checkbox 는
-// change 로 와서 두 이벤트를 모두 받습니다.
+// range inputs fire "input", selects and checkboxes fire "change" -- listen for both.
 const handleSettingChange = (event) => {
   const target = event.target.closest("[data-setting]");
   if (target) settingChanged(target, target.dataset.setting);
@@ -2287,7 +2280,7 @@ const handleSettingChange = (event) => {
 document.addEventListener("input", handleSettingChange);
 document.addEventListener("change", handleSettingChange);
 
-// 요소 자체를 인자로 받는 select 들입니다.
+// Selects whose handler needs the element itself, not just its value.
 const changeActions = { langChanged, rateChanged };
 document.addEventListener("change", (event) => {
   const target = event.target.closest("[data-change]");

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2,9 +2,8 @@
 const safariBlocker = document.getElementById("safariBlocker");
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
-// 응답 본문을 읽기 전에 상태 코드를 봅니다. 4xx·5xx는 본문이 JSON이 아닐 수
-// 있어(프록시가 낸 HTML 오류 페이지 등) 곧바로 json()을 부르면 파싱 오류가 나고,
-// 실제 원인과 무관한 메시지가 사용자에게 노출됩니다.
+// A 4xx/5xx response body isn't guaranteed to be JSON (a proxy's HTML error page,
+// for example), so check the status before parsing to avoid a misleading error.
 function readJson(res) {
   if (!res.ok) {
     throw new Error(`${res.status} ${res.statusText}`);
@@ -12,7 +11,6 @@ function readJson(res) {
   return res.json();
 }
 
-// CSP를 걸기 위해 body의 oncontextmenu 속성에서 옮겨온 것입니다.
 document.addEventListener("contextmenu", (event) => {
   event.preventDefault();
 });
@@ -35,18 +33,15 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     })
     .catch((error) => {
-      // 로그인 여부 확인 실패는 화면을 막지 않습니다. 로그인 버튼은 그대로
-      // 쓸 수 있으므로 콘솔에만 남기고 사용자 흐름은 끊지 않습니다.
+      // A failed status check shouldn't block the page -- the login button still works.
       console.error(error);
     });
 });
 
-// GSI 스크립트가 차단되거나 로드에 실패하면 버튼이 아예 그려지지 않습니다.
-// 그대로 두면 아무 반응 없는 빈 화면으로 보이므로 원인을 알려줍니다.
-// async 스크립트는 load 이벤트를 지연시키므로 이 시점이면 결과가 확정됩니다.
-//
-// alert 대신 화면에 남겨둡니다. 차단기를 쓰는 사용자는 방문할 때마다 걸리는데,
-// 그때마다 팝업을 띄우면 안내가 아니라 방해가 됩니다.
+// If the GSI script is blocked or fails to load, the button never renders and the
+// page looks unresponsive. The load event fires after async scripts, so the
+// result is final by this point. Shown inline rather than via alert, since an ad
+// blocker would trigger this on every visit and a popup each time is disruptive.
 window.addEventListener("load", () => {
   if (!window.google || !window.google.accounts || !window.google.accounts.id) {
     console.error("Google Identity Services failed to load.");
@@ -75,8 +70,7 @@ function handleCredentialResponse(authResult) {
       }
     })
     .catch((error) => {
-      // 오류 문자열을 그대로 띄우면 내부 사정만 새어 나가고 사용자는 할 수 있는
-      // 일이 없습니다. 사람에게는 번역된 문구를, 진단용 원문은 콘솔에 남깁니다.
+      // Show a translated message to the user; log the raw error for diagnostics.
       console.error(error);
       alert(loginError);
     });

--- a/public/js/join.js
+++ b/public/js/join.js
@@ -1,10 +1,9 @@
 /* global api, projectUrl, joini18n */
 
-// 응답 본문을 읽기 전에 상태 코드를 봅니다. 4xx·5xx는 본문이 JSON이 아닐 수
-// 있어(프록시가 낸 HTML 오류 페이지 등) 곧바로 json()을 부르면 파싱 오류가 나고,
-// 실제 원인과 무관한 메시지가 사용자에게 노출됩니다.
-// index.js에도 같은 헬퍼가 있습니다. 두 파일 모두 GSI 콜백을 전역으로 노출해야
-// 해서 클래식 스크립트이고, 공유 파일로 빼려면 뷰의 로딩 순서까지 바꿔야 합니다.
+// A 4xx/5xx response body isn't guaranteed to be JSON (a proxy's HTML error page,
+// for example), so check the status before parsing to avoid a misleading error.
+// Duplicated in index.js: both are classic scripts (they expose a GSI callback
+// globally), and sharing this would mean reworking how the views load scripts.
 function readJson(res) {
   if (!res.ok) {
     throw new Error(`${res.status} ${res.statusText}`);
@@ -29,8 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     })
     .catch((error) => {
-      // 로그인 상태 확인 실패로 가입 화면을 막지는 않습니다. 닉네임을 넣고
-      // 제출하는 흐름은 그대로 쓸 수 있으므로 콘솔에만 남깁니다.
+      // A failed status check shouldn't block the page -- the name field still works.
       console.error(error);
     });
 });
@@ -86,15 +84,13 @@ const check = () => {
         }
       })
       .catch((error) => {
-        // 오류 문자열을 그대로 띄우면 내부 사정만 새어 나가고 사용자는 할 수 있는
-        // 일이 없습니다. 사람에게는 번역된 문구를, 진단용 원문은 콘솔에 남깁니다.
+        // Show a translated message to the user; log the raw error for diagnostics.
         console.error(error);
         alert(joini18n.error);
       });
   }
 };
 
-// CSP를 걸기 위해 제출 버튼의 onclick 속성에서 옮겨온 것입니다.
 document.getElementById("submit").addEventListener("click", check);
 
 document.addEventListener("keydown", (event) => {

--- a/public/js/play.js
+++ b/public/js/play.js
@@ -1,6 +1,6 @@
 /* global Pace, Howler, Howl, url, cdn, api */
-// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
-// 통해 그 값들을 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
+// url/cdn/api etc. are set by the page's inline <script> and by the classic
+// library scripts; a module can read them via global scope with no extra wiring.
 let upperBound, lowerBound, numberWithCommas, easeOutSine, easeOutQuad;
 let Factory, Updater, Renderer;
 (async () => {
@@ -1188,7 +1188,6 @@ document.getElementById("componentCanvas").addEventListener("mouseup", (event) =
   checkHoldNote(`${event.button}mouse`);
 });
 
-// CSP를 걸기 위해 마크업의 on* 속성에서 옮겨온 것들입니다.
 document.addEventListener("contextmenu", (event) => event.preventDefault());
 document.addEventListener("dragstart", (event) => event.preventDefault());
 document.addEventListener("selectstart", (event) => event.preventDefault());

--- a/public/js/test.js
+++ b/public/js/test.js
@@ -1,6 +1,6 @@
 /* global Pace, Howler, Howl, url, cdn, api */
-// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
-// 통해 그 값들을 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
+// url/cdn/api etc. are set by the page's inline <script> and by the classic
+// library scripts; a module can read them via global scope with no extra wiring.
 let upperBound, lowerBound, numberWithCommas, easeOutSine;
 let Factory, Updater, Renderer;
 (async () => {
@@ -1096,7 +1096,6 @@ document.getElementById("componentCanvas").addEventListener("mouseup", (event) =
   checkHoldNote(`${event.button}mouse`);
 });
 
-// CSP를 걸기 위해 마크업의 on* 속성에서 옮겨온 것들입니다.
 document.addEventListener("contextmenu", (event) => event.preventDefault());
 document.addEventListener("dragstart", (event) => event.preventDefault());
 document.addEventListener("selectstart", (event) => event.preventDefault());

--- a/public/js/tutorial.js
+++ b/public/js/tutorial.js
@@ -1,6 +1,6 @@
 /* global Pace, Howler, Howl, url, cdn, api, lang, confirmExit */
-// 값은 페이지의 인라인 <script>와 클래식 라이브러리가 심습니다. 모듈은 전역 스코프를
-// 통해 그 값들을 그대로 읽을 수 있어 추가 조치가 필요 없습니다.
+// url/cdn/api etc. are set by the page's inline <script> and by the classic
+// library scripts; a module can read them via global scope with no extra wiring.
 let upperBound, lowerBound, numberWithCommas, easeOutSine;
 let Factory, Updater, Renderer;
 (async () => {
@@ -1102,7 +1102,6 @@ document.getElementById("componentCanvas").addEventListener("mouseup", (event) =
   checkHoldNote(`${event.button}mouse`);
 });
 
-// CSP를 걸기 위해 마크업의 on* 속성에서 옮겨온 것들입니다.
 document.addEventListener("contextmenu", (event) => event.preventDefault());
 document.addEventListener("dragstart", (event) => event.preventDefault());
 document.addEventListener("selectstart", (event) => event.preventDefault());

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,7 @@ const config = require(__dirname + "/../config/config.json");
 
 const version = require(__dirname + "/../package.json").version;
 
-// 백엔드가 ID 토큰을 검증할 때 쓰는 값과 반드시 같아야 합니다. 템플릿에 직접
-// 적어두면 한쪽만 바뀌었을 때 아무 오류 없이 로그인만 조용히 실패합니다.
+// Must match the value the backend uses to verify the ID token, or login fails silently.
 const googleClientId: string = config.google?.clientId;
 if (!googleClientId) {
   logger.fatal("config.google.clientId is missing. Google login cannot work.");
@@ -49,9 +48,7 @@ app.set("view engine", "ejs");
 app.set("views", __dirname + "/../views");
 app.use(cookieParser());
 
-// Baseline security headers. CSP is applied per-route: the account pages and the
-// three play screens carry it, while editor (136 inline handlers) and game (97)
-// still need the markup cleaned up before a policy can hold there.
+// Baseline security headers applied to every response. CSP itself is set per route.
 app.use((req, res, next) => {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "SAMEORIGIN");
@@ -68,39 +65,28 @@ app.use((req, res, next) => {
 app.use(express.static(__dirname + "/../public", { maxAge: "7d" }));
 app.use(i18n);
 
-/**
- * 계정을 다루는 화면에만 거는 CSP입니다. 이 두 화면은 인라인 이벤트 핸들러가
- * 각각 하나뿐이라 정리 비용이 거의 없으면서, 탈취당했을 때 피해는 가장 큽니다.
- *
- * Chromium으로 두 화면을 실제로 열어 위반이 없는 것과, GSI 버튼이 그려지고
- * /auth/status 요청이 통과하는 것까지 확인한 뒤 강제 모드로 두었습니다.
- * 구글 로그인 완료 이후 경로는 자격증명이 필요해 검증하지 못했지만, 그 단계의
- * 요청도 /auth/status와 같은 오리진이라 connect-src가 이미 덮습니다.
- */
+// Google Identity Services origin, used by the login button's script, style and frame.
 const GSI_ORIGIN = "https://accounts.google.com";
 
 /**
- * @param withGsi 구글 로그인을 쓰는 화면인지. 가입 화면은 GSI를 부르지 않으므로
- *   accounts.google.com을 허용할 이유가 없습니다. 두 화면이 정책을 공유하면
- *   가입 화면이 쓰지도 않는 출처를 열어두게 됩니다.
+ * @param withGsi Whether the page uses Google Sign-In. The join page never calls
+ *   GSI, so it has no reason to allow accounts.google.com.
  */
 const authPageCsp = (nonce: string, withGsi: boolean) => {
   const gsi = (directive: string) => (withGsi ? ` ${directive}` : "");
 
   return [
     "default-src 'self'",
-    // GSI 클라이언트와 페이지가 심는 전역 설정 스크립트를 허용합니다.
+    // Allows the GSI client script and the page's own inline config script.
     `script-src 'self' 'nonce-${nonce}'${gsi(GSI_ORIGIN)}`,
-    // GSI 버튼이 인라인 스타일을 주입해 nonce로 좁힐 수 없습니다.
-    // accounts.google.com은 GSI가 버튼 스타일시트(/gsi/style)를 받아오는 곳으로,
-    // 빠뜨리면 강제 모드에서 로그인 버튼 모양이 깨집니다. 웹폰트(Montserrat·
-    // Pretendard)는 CDN에서 받아옵니다.
+    // The GSI button injects inline styles, so 'unsafe-inline' can't be narrowed to
+    // a nonce. accounts.google.com also serves the button's stylesheet (/gsi/style).
     `style-src 'self' 'unsafe-inline'${gsi(GSI_ORIGIN)}`,
     `font-src 'self' ${config.project.cdn}`,
     "img-src 'self' data:",
     `connect-src 'self' ${config.project.api}${gsi(GSI_ORIGIN)}`,
-    // 로그인 버튼은 accounts.google.com iframe으로 그려집니다. 가입 화면은
-    // 프레임을 전혀 쓰지 않으므로 아예 막습니다.
+    // The login button renders in an accounts.google.com iframe. The join page
+    // uses no frames at all, so it blocks them outright.
     withGsi ? `frame-src ${GSI_ORIGIN}` : "frame-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
@@ -110,32 +96,33 @@ const authPageCsp = (nonce: string, withGsi: boolean) => {
 };
 
 /**
- * 플레이 화면(play·test·tutorial)과 에디터가 공유하는 정책입니다. 계정 화면과
- * 쓰는 출처가 거의 겹치지 않아 합치면 양쪽 모두에게 필요 없는 권한을 열어주게
- * 됩니다.
+ * Policy shared by the play screens (play/test/tutorial) and the editor. They
+ * load the same assets, and their inline handlers use few enough origins that
+ * merging with the account-page policy would only grant unused permissions.
  *
- * 네 화면은 불러오는 자산이 같습니다. 에디터가 패턴을 내려받을 때 만드는 blob
- * URL 은 <a download> 로만 쓰여 페치 지시문의 대상이 아닙니다. socket.io는 이
- * 서버에서 직접 내려주므로 script-src 에 외부 출처가 필요 없습니다.
+ * The editor's pattern download creates a blob URL, but it's only ever used
+ * through <a download>, so it isn't a target for any fetch directive. socket.io
+ * is served by this app itself, so script-src needs no external origin for it.
  */
 const playPageCsp = (nonce: string) => {
-  // socket.io는 폴링(https)으로 붙었다가 웹소켓으로 승격하므로 두 스킴이 다
-  // 필요합니다. 하나만 열어두면 승격 단계나 최초 연결 중 하나가 막힙니다.
+  // socket.io connects over polling (https) before upgrading to a websocket, so
+  // both schemes are needed -- allowing only one breaks either the initial
+  // connection or the upgrade.
   const gameSocket = config.project.game.replace(/^https:/, "wss:");
 
   return [
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}'`,
     "style-src 'self' 'unsafe-inline'",
-    // Montserrat·Pretendard·Metropolis 웹폰트가 모두 CDN에서 옵니다.
+    // The Montserrat, Pretendard and Metropolis webfonts are all served from the CDN.
     `font-src 'self' ${config.project.cdn}`,
-    // 앨범아트와 배경이 CDN에서 옵니다.
+    // Album art and backgrounds come from the CDN.
     `img-src 'self' data: ${config.project.cdn}`,
-    // Howler는 기본적으로 Web Audio로 받아 connect-src를 타지만, 브라우저가
-    // 지원하지 않으면 <audio>로 떨어져 media-src를 탑니다. 어느 쪽으로 가든
-    // 곡이 재생되도록 둘 다 열어둡니다.
+    // Howler prefers Web Audio, which uses connect-src, but falls back to <audio>
+    // (media-src) when that isn't supported. Both are allowed so playback works
+    // either way.
     `media-src 'self' ${config.project.cdn}`,
-    // 패턴·스킨 JSON과 곡 파일(CDN), 기록·설정 API, 게임 서버 소켓입니다.
+    // Pattern/skin JSON and track files (CDN), the record/settings API, and the game socket.
     `connect-src 'self' ${config.project.api} ${config.project.cdn} ${config.project.game} ${gameSocket}`,
     "frame-src 'none'",
     "base-uri 'self'",
@@ -145,8 +132,8 @@ const playPageCsp = (nonce: string) => {
   ].join("; ");
 };
 
-// 요청마다 새로 만듭니다. 재사용하면 공격자가 값을 알아내 인라인 스크립트를
-// 통과시킬 수 있어 nonce의 의미가 사라집니다.
+// Generated fresh per request -- reusing it would let an attacker learn the
+// value and pass off their own inline script, defeating the point of a nonce.
 const withAuthPageCsp = (res: Response, withGsi: boolean): string => {
   const nonce = randomBytes(16).toString("base64");
   res.setHeader("Content-Security-Policy", authPageCsp(nonce, withGsi));
@@ -154,22 +141,13 @@ const withAuthPageCsp = (res: Response, withGsi: boolean): string => {
 };
 
 /**
- * 계정 화면과 달리 Report-Only로 시작합니다. 세 화면은 로그인 세션이 있어야
- * 열려서 브라우저로 위반을 직접 수집하지 못했고, 정책은 코드에서 쓰이는 출처를
- * 훑어 세운 것입니다. 곧바로 강제하면 빠뜨린 출처 하나에 곡이 안 받아지거나
- * 소켓이 끊겨 게임이 멈춥니다.
+ * Policy for the game screen. Mostly the same as the play-screen policy, except
+ * that profile pictures come from two places: uploads live on the CDN, while the
+ * Google account picture captured at signup is served from googleusercontent.
  *
- * 실제 플레이에서 콘솔에 위반이 남지 않는 것을 확인한 뒤 강제로 바꿔야 합니다.
- */
-/**
- * 게임 화면용 정책입니다. 플레이 화면과 대부분 겹치지만 프로필 사진이 두
- * 곳에서 온다는 점이 다릅니다. 직접 올린 사진은 CDN 에 있고, 가입 시점에
- * 받아둔 구글 계정 사진은 googleusercontent 에 있습니다.
- *
- * 랭킹 그래프에 쓰는 chart.js 와 socket.io 도 이 서버에서 직접 내려주므로
- * script-src 에 외부 출처가 필요 없습니다.
- *
- * 플레이 화면과 정책을 합치면 그쪽에 쓰지도 않는 출처를 열어주게 됩니다.
+ * chart.js (the ranking graph) and socket.io are both served by this app itself,
+ * so script-src needs no external origin for either. Merging this with the play
+ * screens' policy would grant them origins they never use.
  */
 const gamePageCsp = (nonce: string) => {
   const gameSocket = config.project.game.replace(/^https:/, "wss:");
@@ -178,9 +156,9 @@ const gamePageCsp = (nonce: string) => {
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}'`,
     "style-src 'self' 'unsafe-inline'",
-    // Montserrat·Pretendard·Metropolis 웹폰트가 모두 CDN에서 옵니다.
+    // The Montserrat, Pretendard and Metropolis webfonts are all served from the CDN.
     `font-src 'self' ${config.project.cdn}`,
-    // 앨범아트·배너는 CDN, 프로필 사진은 CDN 또는 구글 계정 사진입니다.
+    // Album art and banners come from the CDN; profile pictures from the CDN or a Google account picture.
     `img-src 'self' data: ${config.project.cdn} https://*.googleusercontent.com`,
     `media-src 'self' ${config.project.cdn}`,
     `connect-src 'self' ${config.project.api} ${config.project.cdn} ${config.project.game} ${gameSocket}`,
@@ -205,24 +183,18 @@ const withPlayPageCsp = (res: Response): string => {
 };
 
 /**
- * 로그인·가입 화면 전용 예산입니다. 두 화면은 요청마다 nonce를 새로 만들기
- * 때문에 호출 수가 그대로 난수 생성 비용이 됩니다.
- *
- * gateLimiter를 재사용하지 않습니다. 그쪽은 인증 캐시가 있으면 건너뛰는데,
- * 여기는 아직 로그인하지 않은 방문자가 오는 곳이라 그 조건이 성립하지 않습니다.
- *
- * 그래서 한도를 gateLimiter보다 넉넉하게 둡니다. gateLimiter는 캐시 적중분을
- * 건너뛰어 공유 주소 뒤의 사용자끼리 예산을 뺏지 않게 하는데, 이 화면은 모두가
- * 미인증 상태로 들어오므로 그 장치가 없습니다. PC방처럼 여러 명이 한 주소를
- * 쓰는 환경에서 좁게 잡으면 정상 방문자가 진입 자체를 못 합니다.
+ * Own budget for the login/join screens, separate from gateLimiter. That one
+ * skips its count on an auth-cache hit, but every visitor here is signed out,
+ * so that escape hatch never applies -- the limit is set generously so users
+ * behind a shared address (e.g. a NAT) aren't locked out of signing in.
  */
 const authPageLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 240,
   standardHeaders: true,
   legacyHeaders: false,
-  // 기본 응답은 평문 한 줄이라 랜딩 페이지에서 장애처럼 보입니다. 나머지 오류와
-  // 같은 화면·번역을 쓰도록 넘깁니다.
+  // The default response is a bare line of text, which looks broken on a landing
+  // page. Route it through the same error screen as everything else.
   handler: (req, res) => sendError(req, res, 429),
 });
 
@@ -325,9 +297,8 @@ const unavailable = (req: Request, res: Response) => {
 };
 
 /**
- * Gate the pages that only make sense for a signed-in player. The status ->
- * destination mapping is the one the pages used to run in the browser; doing it
- * here means the check cannot be skipped by disabling JavaScript.
+ * Gate the pages that only make sense for a signed-in player. Doing this
+ * server-side means the check cannot be skipped by disabling JavaScript.
  */
 const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
   // Depends on the session, so neither the CDN nor the browser may cache it.
@@ -495,8 +466,8 @@ process.on("uncaughtException", (error: Error) => {
   try {
     await initProfile();
 
-    // 리버스 프록시가 앞에 있으므로 기본값은 루프백입니다. 와일드카드로 열면
-    // 포트가 방화벽 정책과 무관하게 외부에 그대로 노출됩니다.
+    // Defaults to loopback since a reverse proxy sits in front; a wildcard bind
+    // would expose the port directly regardless of firewall policy.
     const host = config.project.host ?? "127.0.0.1";
     app.listen(config.project.port, host, () => {
       logger.info(`URLATE-v3l-frontend is running on version ${config.project.mode == "test" ? Date.now() : version}.`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -31,18 +31,12 @@ function rotate(filePath: string): void {
   if (fs.existsSync(filePath)) fs.renameSync(filePath, `${filePath}.1`);
 }
 
-/**
- * Format log entry with timestamp
- */
 function formatLogEntry(level: string, message: string, meta?: any): string {
   const timestamp = new Date().toISOString();
   const metaStr = meta ? `\n${JSON.stringify(meta, null, 2)}` : "";
   return `[${timestamp}] [${level}] ${message}${metaStr}\n`;
 }
 
-/**
- * Write log to file
- */
 function writeToFile(filePath: string, content: string): void {
   try {
     const bytes = Buffer.byteLength(content, "utf8");
@@ -62,9 +56,6 @@ function writeToFile(filePath: string, content: string): void {
   }
 }
 
-/**
- * Logger class for centralized logging
- */
 class Logger {
   info(message: string, meta?: any): void {
     signale.info(message);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,24 +16,22 @@ const translate = (res: Response, key: string, fallback: string): string => {
 };
 
 /**
- * 안내·오류 화면(info·privacy·error)용 정책입니다. 세 화면은 스크립트를 하나도
- * 부르지 않아 script-src를 통째로 막을 수 있고, 그래서 nonce도 필요 없습니다.
- * 나중에 누군가 인라인 스크립트를 넣으면 조용히 동작하는 대신 바로 막히므로,
- * 이 화면들이 정적이라는 전제가 깨지는 순간 드러납니다.
+ * Policy for the static screens (info/privacy/error). None of them load any
+ * script, so script-src is blocked outright and no nonce is needed -- if
+ * someone later adds an inline script, it fails loudly instead of silently.
  *
- * default-src를 'none'으로 두고 실제로 쓰는 것만 하나씩 엽니다. 인라인 style
- * 속성도 없어 style-src에 unsafe-inline을 넣지 않았습니다. 웹폰트(Montserrat·
- * Pretendard)는 CDN에서 받아옵니다.
+ * default-src is 'none', with only what's actually used opened back up. There
+ * are no inline style attributes either, so style-src omits 'unsafe-inline'.
  *
- * 오류 화면과 같은 정책을 쓰기 때문에 여기에 둡니다. index에서 정의해 가져가면
- * 순환 참조가 됩니다.
+ * Defined here rather than in index.ts because the error page shares this
+ * policy and importing it from index.ts would create a circular reference.
  */
 const STATIC_PAGE_CSP = [
   "default-src 'none'",
   "script-src 'none'",
   "style-src 'self'",
   `font-src 'self' ${config.project.cdn}`,
-  // 파비콘과 안내 화면의 아이콘뿐이고 전부 이 서버에서 옵니다.
+  // Just the favicon and the info page's icons, all served by this app.
   "img-src 'self'",
   "base-uri 'none'",
   "form-action 'none'",
@@ -82,8 +80,8 @@ export const sendError = (req: Request, res: Response, status: number): void => 
   // req.accepts honours the order of the Accept header. fetch/XHR usually asks
   // for JSON first, so they get JSON instead of the page.
   if (req.accepts(["html", "json"]) === "html") {
-    // 어느 경로에서 왔든 오류 화면 자체는 정적입니다. 원래 경로에 걸려 있던
-    // 넉넉한 정책을 그대로 물려받지 않도록 여기서 다시 지정합니다.
+    // The error page itself is static regardless of where the request came from,
+    // so reset the policy rather than inherit whatever the original route set.
     setStaticPageCsp(res);
     res.render(
       "error",
@@ -114,10 +112,6 @@ export function notFoundHandler(req: Request, res: Response): void {
   sendError(req, res, 404);
 }
 
-/**
- * Express error handling middleware
- * Logs errors and sends appropriate responses
- */
 export function errorHandler(err: any, req: Request, res: Response, next: NextFunction): void {
   logger.error("Request error occurred", err, {
     method: req.method,

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -122,8 +122,7 @@
           <img src="/images/parts/elements/TRACKS.webp" id="tracks" />
           <div id="tracksLine"></div>
           <span class="tracksSelection selected">
-            <strong>Official</strong> Pattern
-            <!--<span class="bottomArrow">▼</span> --></span
+            <strong>Official</strong> Pattern</span
           >
           <span class="tracksSelection"> <strong>Community</strong> Pattern <span class="bottomArrow">▼</span> </span>
         </div>
@@ -606,8 +605,6 @@
             <input type="checkbox" class="optionCheckbox" id="judgeBad" data-setting="Bad" />
             <p class="optionSemiTitle">Miss</p>
             <input type="checkbox" class="optionCheckbox" id="judgeMiss" data-setting="Miss" />
-            <!-- <p class="optionSemiTitle">Bullet</p>
-                    <input type="checkbox" class="optionCheckbox" id="judgeBullet" data-setting="Bullet"> -->
           </div>
           <p class="optionTitle"><%= __('info') %></p>
           <div class="optionValueContainer">


### PR DESCRIPTION
## Summary
- Delete comments that only narrate a past change (CSP migration notes, "moved from on* attribute" markers, a stale progress note that no longer matches the code)
- Translate remaining Korean comments to English
- Drop boilerplate JSDoc that just restates the function name (`logger.ts`)
- Remove two dead commented-out blocks with no documentation value (`editor.css`, `game.ejs`)
- Keep comments that explain non-obvious rationale (nonce regeneration, why `focus`/`blur` need `focusin`/`focusout` for delegation, CSP directive reasoning) and comments that organize code into sections (mode markers, UP/DOWN branches, algorithm step labels)

Vendored files (`public/lib/*`, `pace.js`, generated font CSS) are untouched.

## Test plan
- [x] `pnpm run build` (tsc) passes
- [x] `eslint` on all touched JS/TS passes with no errors
- [x] All 10 EJS views render successfully with representative locals
- [x] `deploy.yml` still parses as valid YAML
- [x] Verified no unintended CRLF→LF line-ending changes remain in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)